### PR TITLE
feat: implement OTP verification page (#67)

### DIFF
--- a/frontend/src/app/(auth)/verify-otp/layout.tsx
+++ b/frontend/src/app/(auth)/verify-otp/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function VerifyOtpLayout({ children }: { readonly children: ReactNode }) {
+  return children;
+}

--- a/frontend/src/app/(auth)/verify-otp/page.tsx
+++ b/frontend/src/app/(auth)/verify-otp/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useRef, useState, KeyboardEvent, ClipboardEvent } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { ResendButton } from "@/components/auth/ResendButton";
+
+function maskEmail(email: string): string {
+  const [local, domain] = email.split("@");
+  if (!domain) return email;
+  return `${local[0]}***@${domain}`;
+}
+
+const inputClass =
+  "h-12 w-12 rounded-xl border border-[#D7CFC6] bg-[#EDE2D6] text-center text-lg font-semibold text-[#1A1A1A] focus:outline-none focus:ring-2 focus:ring-[#1A1A1A] caret-transparent";
+
+export default function VerifyOtpPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const email = params.get("email") ?? "";
+
+  const [digits, setDigits] = useState(["", "", "", "", "", ""]);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const refs = useRef<(HTMLInputElement | null)[]>([]);
+
+  const focus = (i: number) => refs.current[i]?.focus();
+
+  const handleChange = (i: number, val: string) => {
+    const digit = val.replace(/\D/g, "").slice(-1);
+    const next = [...digits];
+    next[i] = digit;
+    setDigits(next);
+    if (digit && i < 5) focus(i + 1);
+  };
+
+  const handleKeyDown = (i: number, e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Backspace" && !digits[i] && i > 0) focus(i - 1);
+  };
+
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, 6);
+    const next = [...digits];
+    pasted.split("").forEach((d, i) => { next[i] = d; });
+    setDigits(next);
+    focus(Math.min(pasted.length, 5));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const otp = digits.join("");
+    if (otp.length < 6) { setError("Please enter all 6 digits."); return; }
+    setError(null);
+    setIsPending(true);
+    try {
+      await api.verifyOtp(email, otp);
+      router.push("/dashboard");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invalid or expired OTP.");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-xl font-semibold text-[#1A1A1A]">Verify your email</h2>
+        <p className="mt-1 text-sm text-[#6B6B6B]">
+          Enter the 6-digit code sent to <span className="font-medium text-[#1A1A1A]">{maskEmail(email)}</span>
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        {error && (
+          <div role="alert" className="rounded-2xl border border-[#D4916E] bg-[#F3EBE2] px-4 py-3 text-sm text-[#1A1A1A]">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-between gap-2">
+          {digits.map((d, i) => (
+            <input
+              key={i}
+              ref={(el) => { refs.current[i] = el; }}
+              type="text"
+              inputMode="numeric"
+              maxLength={1}
+              value={d}
+              autoFocus={i === 0}
+              aria-label={`Digit ${i + 1}`}
+              className={inputClass}
+              onChange={(e) => handleChange(i, e.target.value)}
+              onKeyDown={(e) => handleKeyDown(i, e)}
+              onPaste={handlePaste}
+            />
+          ))}
+        </div>
+
+        <Button type="submit" disabled={isPending} className="w-full">
+          {isPending ? "Verifying…" : "Verify"}
+        </Button>
+      </form>
+
+      <ResendButton email={email} />
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/verify-otp/page.tsx
+++ b/frontend/src/app/(auth)/verify-otp/page.tsx
@@ -27,16 +27,20 @@ export default function VerifyOtpPage() {
 
   const focus = (i: number) => refs.current[i]?.focus();
 
-  const handleChange = (i: number, val: string) => {
-    const digit = val.replace(/\D/g, "").slice(-1);
-    const next = [...digits];
-    next[i] = digit;
-    setDigits(next);
-    if (digit && i < 5) focus(i + 1);
-  };
-
   const handleKeyDown = (i: number, e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Backspace" && !digits[i] && i > 0) focus(i - 1);
+    if (e.key === "Backspace") {
+      e.preventDefault();
+      const next = [...digits];
+      if (next[i]) { next[i] = ""; setDigits(next); }
+      else if (i > 0) { next[i - 1] = ""; setDigits(next); focus(i - 1); }
+      return;
+    }
+    if (!/^\d$/.test(e.key)) return;
+    e.preventDefault();
+    const next = [...digits];
+    next[i] = e.key;
+    setDigits(next);
+    if (i < 5) focus(i + 1);
   };
 
   const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
@@ -92,7 +96,7 @@ export default function VerifyOtpPage() {
               autoFocus={i === 0}
               aria-label={`Digit ${i + 1}`}
               className={inputClass}
-              onChange={(e) => handleChange(i, e.target.value)}
+              onChange={() => {}}
               onKeyDown={(e) => handleKeyDown(i, e)}
               onPaste={handlePaste}
             />

--- a/frontend/src/components/auth/ResendButton.tsx
+++ b/frontend/src/components/auth/ResendButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { CountDownTimer } from "@/components/ui/CountDownTimer";
+
+const RESEND_SECONDS = 60;
+
+export function ResendButton({ email }: Readonly<{ email: string }>) {
+  const [counting, setCounting] = useState(true);
+  const [timerKey, setTimerKey] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const handleExpire = useCallback(() => setCounting(false), []);
+
+  const handleResend = async () => {
+    setIsPending(true);
+    setError(null);
+    try {
+      await api.resendOtp(email);
+      setCounting(true);
+      setTimerKey((k) => k + 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to resend OTP.");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      {counting ? (
+        <p className="text-sm text-[#6B6B6B]">
+          Resend code in <CountDownTimer key={timerKey} seconds={RESEND_SECONDS} onExpire={handleExpire} />
+        </p>
+      ) : (
+        <Button type="button" variant="soft" disabled={isPending} onClick={handleResend} className="text-sm">
+          {isPending ? "Sending…" : "Resend code"}
+        </Button>
+      )}
+      {error && <p className="text-xs text-[#D4916E]">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/CountDownTimer.tsx
+++ b/frontend/src/components/ui/CountDownTimer.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface CountDownTimerProps {
+  seconds: number;
+  onExpire: () => void;
+}
+
+export function CountDownTimer({ seconds, onExpire }: Readonly<CountDownTimerProps>) {
+  const [remaining, setRemaining] = useState(seconds);
+
+  useEffect(() => {
+    setRemaining(seconds);
+  }, [seconds]);
+
+  useEffect(() => {
+    if (remaining <= 0) { onExpire(); return; }
+    const id = setTimeout(() => setRemaining((r) => r - 1), 1000);
+    return () => clearTimeout(id);
+  }, [remaining, onExpire]);
+
+  return <span className="tabular-nums text-[#6B6B6B]">{remaining}s</span>;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,4 +26,16 @@ export const api = {
     request<unknown[]>('/users', {
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     }),
+
+  verifyOtp: (email: string, otp: string) =>
+    request<{ access_token: string }>('/auth/verify-otp', {
+      method: 'POST',
+      body: JSON.stringify({ email, otp }),
+    }),
+
+  resendOtp: (email: string) =>
+    request<{ message: string }>('/auth/resend-otp', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    }),
 };


### PR DESCRIPTION
## Summary
Implements the OTP verification flow as described in issue #67.  Closes #67

## Changes
- **`app/(auth)/verify-otp/page.tsx`** — 6 individual digit inputs with auto-advance focus, backspace navigation, paste support, masked email display, calls `POST /api/auth/verify-otp`, redirects to `/dashboard` on success, shows error on failure
- **`app/(auth)/verify-otp/layout.tsx`** — minimal layout wrapper
- **`components/auth/ResendButton.tsx`** — calls `POST /api/auth/resend-otp`, disabled during 60s countdown, re-enables on expiry
- **`components/ui/CountDownTimer.tsx`** — reusable countdown timer component
- **`lib/api.ts`** — added `verifyOtp` and `resendOtp` API methods

## Tested
- TypeScript type-check passes (`tsc --noEmit`)