### PR TITLE
feat: implement forgot password and reset password pages (#68)

### DIFF
--- a/frontend/src/app/(auth)/forgot-password/page.tsx
+++ b/frontend/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,17 @@
+import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-xl font-semibold text-[#1A1A1A]">Forgot password</h2>
+        <p className="mt-1 text-sm text-[#6B6B6B]">Enter your email and we&apos;ll send you a reset code.</p>
+      </div>
+      <ForgotPasswordForm />
+      <p className="text-center text-sm text-[#6B6B6B]">
+        Remember your password?{" "}
+        <a href="/login" className="font-semibold text-[#1A1A1A] underline hover:text-[#3D3D3D]">Sign in</a>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import { LoginForm } from "@/components/auth/LoginForm";
 import { BiometricLoginView } from "@/components/auth/BiometricLoginView";
 
 export default function LoginPage() {
+  const reset = useSearchParams().get("reset");
+
   const handleBiometric = () => {
     // WebAuthn / biometric flow — to be wired in #66
     alert("Biometric login coming soon");
@@ -11,6 +14,12 @@ export default function LoginPage() {
 
   return (
     <div className="flex flex-col gap-6">
+      {reset === "success" && (
+        <div role="status" className="rounded-2xl border border-[#A8C5A0] bg-[#EAF3E8] px-4 py-3 text-sm text-[#1A1A1A]">
+          Password reset successfully — sign in with your new password.
+        </div>
+      )}
+
       <div>
         <h2 className="text-xl font-semibold text-[#1A1A1A]">Sign in</h2>
         <p className="mt-1 text-sm text-[#6B6B6B]">Welcome back — enter your details below.</p>

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { ResetPasswordLayout } from "@/components/auth/ResetPasswordLayout";
+import { ResetPasswordCard } from "@/components/auth/ResetPasswordCard";
+
+export default function ResetPasswordPage() {
+  const email = useSearchParams().get("email") ?? "";
+
+  return (
+    <ResetPasswordLayout>
+      <ResetPasswordCard email={email} />
+    </ResetPasswordLayout>
+  );
+}

--- a/frontend/src/components/auth/EmailResetPassword.tsx
+++ b/frontend/src/components/auth/EmailResetPassword.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@/components/ui/Button";
+
+const schema = z.object({ email: z.string().email("Enter a valid email address") });
+type Values = z.infer<typeof schema>;
+
+interface Props {
+  onSubmit: (email: string) => Promise<void>;
+  isPending: boolean;
+  error: string | null;
+}
+
+const inputClass =
+  "w-full rounded-full border border-[#D7CFC6] bg-[#EDE2D6] px-4 py-3 text-sm text-[#1A1A1A] placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-[#1A1A1A]";
+
+export function EmailResetPassword({ onSubmit, isPending, error }: Readonly<Props>) {
+  const { register, handleSubmit, formState: { errors } } = useForm<Values>({ resolver: zodResolver(schema) });
+
+  return (
+    <form onSubmit={handleSubmit((v) => onSubmit(v.email))} className="flex flex-col gap-5">
+      {error && (
+        <div role="alert" className="rounded-2xl border border-[#D4916E] bg-[#F3EBE2] px-4 py-3 text-sm text-[#1A1A1A]">
+          {error}
+        </div>
+      )}
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-semibold tracking-[0.1em] text-[#6B6B6B]">EMAIL</label>
+        <input type="email" autoComplete="email" placeholder="you@workspace.com" {...register("email")} className={inputClass} />
+        {errors.email && <p className="text-xs text-[#D4916E]">{errors.email.message}</p>}
+      </div>
+      <Button type="submit" disabled={isPending} className="w-full">
+        {isPending ? "Sending…" : "Send reset code"}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/components/auth/ForgotPasswordForm.tsx
+++ b/frontend/src/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { EmailResetPassword } from "@/components/auth/EmailResetPassword";
+
+export function ForgotPasswordForm() {
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (email: string) => {
+    setIsPending(true);
+    setError(null);
+    try {
+      await api.forgotPassword(email);
+      setSent(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong.");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  if (sent) {
+    return (
+      <div className="rounded-2xl border border-[#D7CFC6] bg-[#EDE2D6] px-4 py-5 text-sm text-[#1A1A1A]">
+        Check your inbox — we&apos;ve sent a password reset code to your email address.
+      </div>
+    );
+  }
+
+  return <EmailResetPassword onSubmit={handleSubmit} isPending={isPending} error={error} />;
+}

--- a/frontend/src/components/auth/ResendPassword.tsx
+++ b/frontend/src/components/auth/ResendPassword.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { CountDownTimer } from "@/components/ui/CountDownTimer";
+
+const RESEND_SECONDS = 60;
+
+export function ResendPassword({ email }: Readonly<{ email: string }>) {
+  const [counting, setCounting] = useState(true);
+  const [timerKey, setTimerKey] = useState(0);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleExpire = useCallback(() => setCounting(false), []);
+
+  const handleResend = async () => {
+    setIsPending(true);
+    setError(null);
+    try {
+      await api.forgotPassword(email);
+      setCounting(true);
+      setTimerKey((k) => k + 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to resend.");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      {counting ? (
+        <p className="text-sm text-[#6B6B6B]">
+          Resend code in <CountDownTimer key={timerKey} seconds={RESEND_SECONDS} onExpire={handleExpire} />
+        </p>
+      ) : (
+        <Button type="button" variant="soft" disabled={isPending} onClick={handleResend} className="text-sm">
+          {isPending ? "Sending…" : "Resend code"}
+        </Button>
+      )}
+      {error && <p className="text-xs text-[#D4916E]">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/auth/ResetPasswordCard.tsx
+++ b/frontend/src/components/auth/ResetPasswordCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { resetPasswordSchema, type ResetPasswordValues } from "@/lib/schemas/resetPasswordSchema";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { ResendPassword } from "@/components/auth/ResendPassword";
+
+const inputClass =
+  "w-full rounded-full border border-[#D7CFC6] bg-[#EDE2D6] px-4 py-3 text-sm text-[#1A1A1A] placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-[#1A1A1A]";
+
+export function ResetPasswordCard({ email }: Readonly<{ email: string }>) {
+  const router = useRouter();
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const { register, handleSubmit, formState: { errors, isSubmitting }, setError } =
+    useForm<ResetPasswordValues>({ resolver: zodResolver(resetPasswordSchema) });
+
+  const onSubmit = async ({ otp, newPassword }: ResetPasswordValues) => {
+    try {
+      await api.resetPassword(email, otp, newPassword);
+      router.push("/login?reset=success");
+    } catch (e) {
+      setError("root", { message: e instanceof Error ? e.message : "Invalid or expired code." });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+      {errors.root && (
+        <div role="alert" className="rounded-2xl border border-[#D4916E] bg-[#F3EBE2] px-4 py-3 text-sm text-[#1A1A1A]">
+          {errors.root.message}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-semibold tracking-[0.1em] text-[#6B6B6B]">RESET CODE</label>
+        <input placeholder="6-digit code" maxLength={6} {...register("otp")} className={inputClass} />
+        {errors.otp && <p className="text-xs text-[#D4916E]">{errors.otp.message}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-semibold tracking-[0.1em] text-[#6B6B6B]">NEW PASSWORD</label>
+        <div className="relative">
+          <input
+            type={showNew ? "text" : "password"}
+            autoComplete="new-password"
+            placeholder="••••••••"
+            {...register("newPassword")}
+            className={`${inputClass} pr-11`}
+          />
+          <button type="button" onClick={() => setShowNew((v) => !v)} aria-label={showNew ? "Hide" : "Show"}
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-[#6B6B6B] hover:text-[#1A1A1A]">
+            {showNew ? "🙈" : "👁️"}
+          </button>
+        </div>
+        {errors.newPassword && <p className="text-xs text-[#D4916E]">{errors.newPassword.message}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-semibold tracking-[0.1em] text-[#6B6B6B]">CONFIRM PASSWORD</label>
+        <div className="relative">
+          <input
+            type={showConfirm ? "text" : "password"}
+            autoComplete="new-password"
+            placeholder="••••••••"
+            {...register("confirmPassword")}
+            className={`${inputClass} pr-11`}
+          />
+          <button type="button" onClick={() => setShowConfirm((v) => !v)} aria-label={showConfirm ? "Hide" : "Show"}
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-[#6B6B6B] hover:text-[#1A1A1A]">
+            {showConfirm ? "🙈" : "👁️"}
+          </button>
+        </div>
+        {errors.confirmPassword && <p className="text-xs text-[#D4916E]">{errors.confirmPassword.message}</p>}
+      </div>
+
+      <Button type="submit" disabled={isSubmitting} className="w-full">
+        {isSubmitting ? "Resetting…" : "Reset password"}
+      </Button>
+
+      <ResendPassword email={email} />
+    </form>
+  );
+}

--- a/frontend/src/components/auth/ResetPasswordLayout.tsx
+++ b/frontend/src/components/auth/ResetPasswordLayout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export function ResetPasswordLayout({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-xl font-semibold text-[#1A1A1A]">Reset password</h2>
+        <p className="mt-1 text-sm text-[#6B6B6B]">Enter the code from your email and choose a new password.</p>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/CountDownTimer.tsx
+++ b/frontend/src/components/ui/CountDownTimer.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface CountDownTimerProps {
+  seconds: number;
+  onExpire: () => void;
+}
+
+export function CountDownTimer({ seconds, onExpire }: Readonly<CountDownTimerProps>) {
+  const [remaining, setRemaining] = useState(seconds);
+
+  useEffect(() => { setRemaining(seconds); }, [seconds]);
+
+  useEffect(() => {
+    if (remaining <= 0) { onExpire(); return; }
+    const id = setTimeout(() => setRemaining((r) => r - 1), 1000);
+    return () => clearTimeout(id);
+  }, [remaining, onExpire]);
+
+  return <span className="tabular-nums text-[#6B6B6B]">{remaining}s</span>;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,4 +26,16 @@ export const api = {
     request<unknown[]>('/users', {
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     }),
+
+  forgotPassword: (email: string) =>
+    request<{ message: string }>('/auth/forgot-password', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    }),
+
+  resetPassword: (email: string, otp: string, newPassword: string) =>
+    request<{ message: string }>('/auth/reset-password', {
+      method: 'POST',
+      body: JSON.stringify({ email, otp, newPassword }),
+    }),
 };

--- a/frontend/src/lib/schemas/resetPasswordSchema.ts
+++ b/frontend/src/lib/schemas/resetPasswordSchema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const resetPasswordSchema = z
+  .object({
+    otp: z.string().length(6, "Enter the 6-digit code"),
+    newPassword: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((d) => d.newPassword === d.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type ResetPasswordValues = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
## Summary
Implements the full password reset flow as described in issue #68. Closes #68 

## Pages
- `/forgot-password` — email input, calls `POST /api/auth/forgot-password`, shows inline success message
- `/reset-password?email=...` — OTP + new password + confirm, calls `POST /api/auth/reset-password`, redirects to `/login?reset=success`
- `/login` — shows green success banner when `?reset=success` is present

## New Components
| File | Purpose |
|------|---------|
| `EmailResetPassword.tsx` | Reusable email input step with zod validation |
| `ForgotPasswordForm.tsx` | Stateful wrapper — switches to success message after send |
| `ResetPasswordCard.tsx` | OTP + password fields with show/hide toggles |
| `ResetPasswordLayout.tsx` | Layout wrapper with heading/subtext |
| `ResendPassword.tsx` | 60s countdown resend button for reset OTP |
| `CountDownTimer.tsx` | Reusable countdown timer (ui component) |

## Other Changes
- `lib/schemas/resetPasswordSchema.ts` — zod schema with password-match refinement
- `lib/api.ts` — `forgotPassword` and `resetPassword` methods

## Tested
- `tsc --noEmit` passes clean