### PR TITLE
feat: build dashboard layout with sidebar navigation (#69)

### DIFF
--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { DashboardLayout } from "@/components/dashboard/DashboardLayout";
+
+export default function Layout({ children }: Readonly<{ children: ReactNode }>) {
+  return <DashboardLayout>{children}</DashboardLayout>;
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useAuthStore } from "@/lib/store/authStore";
+
+export default function DashboardPage() {
+  const user = useAuthStore((s) => s.user);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h1 className="text-2xl font-semibold text-[#1A1A1A]">
+        Welcome back{user?.name ? `, ${user.name}` : ""}
+      </h1>
+      <p className="text-sm text-[#6B6B6B]">Here&apos;s what&apos;s happening in your workspace today.</p>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardLayout.tsx
+++ b/frontend/src/components/dashboard/DashboardLayout.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
+
+export function DashboardLayout({ children }: Readonly<{ children: ReactNode }>) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen bg-[#C5BEB6]">
+      {/* Desktop sidebar */}
+      <div className="hidden lg:flex lg:shrink-0">
+        <DashboardSidebar />
+      </div>
+
+      {/* Mobile sidebar overlay */}
+      {sidebarOpen && (
+        <div className="fixed inset-0 z-40 flex lg:hidden">
+          <div className="fixed inset-0 bg-black/40" onClick={() => setSidebarOpen(false)} aria-hidden />
+          <div className="relative z-50 flex h-full">
+            <DashboardSidebar onClose={() => setSidebarOpen(false)} />
+          </div>
+        </div>
+      )}
+
+      {/* Main */}
+      <div className="flex flex-1 flex-col min-w-0">
+        {/* Mobile topbar */}
+        <header className="flex items-center gap-3 border-b border-[#D7CFC6] bg-[#F3EBE2] px-4 py-3 lg:hidden">
+          <button
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Open menu"
+            className="rounded-lg p-1.5 text-[#6B6B6B] hover:bg-[#EDE2D6] hover:text-[#1A1A1A]"
+          >
+            ☰
+          </button>
+          <span className="text-base font-semibold text-[#1A1A1A]">Hubassist</span>
+        </header>
+
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/DashboardSidebar.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useAuthStore } from "@/lib/store/authStore";
+
+const NAV = [
+  { href: "/dashboard", label: "Dashboard", icon: "⊞" },
+  { href: "/dashboard/workspaces", label: "Workspaces", icon: "🏢" },
+  { href: "/dashboard/bookings", label: "Bookings", icon: "📅" },
+  { href: "/dashboard/attendance", label: "Attendance", icon: "🕐" },
+  { href: "/dashboard/profile", label: "Profile", icon: "👤" },
+  { href: "/dashboard/settings", label: "Settings", icon: "⚙️", adminOnly: true },
+] as const;
+
+interface Props {
+  onClose?: () => void;
+}
+
+export function DashboardSidebar({ onClose }: Readonly<Props>) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const user = useAuthStore((s) => s.user);
+  const clear = useAuthStore((s) => s.clear);
+
+  const handleLogout = () => {
+    clear();
+    router.push("/login");
+  };
+
+  const links = NAV.filter((n) => !("adminOnly" in n && n.adminOnly && user?.role !== "admin"));
+
+  return (
+    <aside className="flex h-full w-64 flex-col bg-[#F3EBE2] border-r border-[#D7CFC6]">
+      {/* Logo */}
+      <div className="flex items-center justify-between px-6 py-5 border-b border-[#D7CFC6]">
+        <span className="text-lg font-semibold text-[#1A1A1A]">Hubassist</span>
+        {onClose && (
+          <button onClick={onClose} aria-label="Close menu" className="text-[#6B6B6B] hover:text-[#1A1A1A] lg:hidden">
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* Nav */}
+      <nav className="flex-1 overflow-y-auto px-3 py-4 flex flex-col gap-1">
+        {links.map(({ href, label, icon }) => {
+          const active = pathname === href || (href !== "/dashboard" && pathname.startsWith(href));
+          return (
+            <Link
+              key={href}
+              href={href}
+              onClick={onClose}
+              className={`flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${
+                active
+                  ? "bg-[#1A1A1A] text-[#F3EBE2]"
+                  : "text-[#3D3D3D] hover:bg-[#EDE2D6]"
+              }`}
+            >
+              <span className="text-base leading-none">{icon}</span>
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* User + Logout */}
+      <div className="border-t border-[#D7CFC6] px-4 py-4 flex items-center gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#D5DCBA] text-sm font-semibold text-[#1A1A1A]">
+          {user?.name?.[0]?.toUpperCase() ?? "?"}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="truncate text-sm font-medium text-[#1A1A1A]">{user?.name ?? "User"}</p>
+          <p className="truncate text-xs capitalize text-[#6B6B6B]">{user?.role ?? "member"}</p>
+        </div>
+        <button
+          onClick={handleLogout}
+          aria-label="Log out"
+          className="shrink-0 rounded-lg p-1.5 text-[#6B6B6B] hover:bg-[#EDE2D6] hover:text-[#1A1A1A] transition-colors"
+        >
+          ↩
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/lib/store/authStore.ts
+++ b/frontend/src/lib/store/authStore.ts
@@ -1,13 +1,24 @@
 import { create } from "zustand/react";
 
+export type UserRole = "admin" | "member" | "staff";
+
+interface User {
+  name: string;
+  role: UserRole;
+}
+
 interface AuthState {
   token: string | null;
+  user: User | null;
   setToken: (token: string) => void;
+  setUser: (user: User) => void;
   clear: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   token: null,
+  user: null,
   setToken: (token) => set({ token }),
-  clear: () => set({ token: null }),
+  setUser: (user) => set({ user }),
+  clear: () => set({ token: null, user: null }),
 }));


### PR DESCRIPTION
## Summary
Implements the main dashboard shell as described in issue #69. Closes #69

## Components
| File | Description |
|------|-------------|
| `components/dashboard/DashboardSidebar.tsx` | Logo, nav links, user avatar + name + role, logout. Admin-only links (Settings) hidden for non-admins. Active link highlighted via `usePathname`. |
| `components/dashboard/DashboardLayout.tsx` | Desktop: fixed `lg:w-64` sidebar. Mobile: hidden by default, toggled via hamburger button, backdrop overlay to dismiss. |
| `app/dashboard/layout.tsx` | Applies `DashboardLayout` to all `/dashboard/**` routes. |
| `app/dashboard/page.tsx` | Welcome stub page showing user's name. |

## Auth Store
Extended `authStore.ts` with `user: { name, role }` and `setUser()` — callers (login flow) should call `setUser` after receiving the token.

## Nav Links
Dashboard · Workspaces · Bookings · Attendance · Profile · Settings *(admin only)*

## Tested
- `tsc --noEmit` passes clean