### PR TITLE
feat(contracts): build common_types library and manage_hub contract modules

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -2,8 +2,10 @@
 members = [
     "contracts/hubassist_hub",
     "contracts/workspace_booking",
+    "contracts/common_types",
 ]
 resolver = "2"
 
 [workspace.dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+common_types = { path = "contracts/common_types" }

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "contracts/hubassist_hub",
     "contracts/workspace_booking",
     "contracts/common_types",
+    "contracts/manage_hub",
 ]
 resolver = "2"
 

--- a/contracts/common_types/Cargo.toml
+++ b/contracts/common_types/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
-name = "workspace_booking"
+name = "common_types"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
-common_types = { workspace = true }

--- a/contracts/common_types/src/lib.rs
+++ b/contracts/common_types/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+
+mod types;
+
+pub use types::{
+    AttendanceFrequency, DateRange, DayPattern, MembershipStatus, MetadataValue, PeakHourData,
+    SubscriptionTier, TierChangeRequest, TierChangeStatus, TierChangeType, TierFeature, TierLevel,
+    TierPromotion, TimePeriod, UserAttendanceStats,
+};
+
+#[cfg(any(test, feature = "testutils"))]
+pub mod test_contract;

--- a/contracts/common_types/src/lib.rs
+++ b/contracts/common_types/src/lib.rs
@@ -4,8 +4,8 @@ mod types;
 
 pub use types::{
     AttendanceFrequency, DateRange, DayPattern, MembershipStatus, MetadataValue, PeakHourData,
-    SubscriptionTier, TierChangeRequest, TierChangeStatus, TierChangeType, TierFeature, TierLevel,
-    TierPromotion, TimePeriod, UserAttendanceStats,
+    Subscription, SubscriptionStatus, SubscriptionTier, TierChangeRequest, TierChangeStatus,
+    TierChangeType, TierFeature, TierLevel, TierPromotion, TimePeriod, UserAttendanceStats,
 };
 
 #[cfg(any(test, feature = "testutils"))]

--- a/contracts/common_types/src/test_contract.rs
+++ b/contracts/common_types/src/test_contract.rs
@@ -1,0 +1,40 @@
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+use crate::{MembershipStatus, TierLevel, TimePeriod};
+
+#[contract]
+pub struct TypesTestContract;
+
+#[contractimpl]
+impl TypesTestContract {
+    pub fn check_status(_env: Env) -> MembershipStatus {
+        MembershipStatus::Active
+    }
+
+    pub fn check_tier(_env: Env) -> TierLevel {
+        TierLevel::Basic
+    }
+
+    pub fn check_period(_env: Env) -> TimePeriod {
+        TimePeriod::Monthly
+    }
+
+    pub fn check_peak_hours(env: Env) -> Vec<crate::PeakHourData> {
+        Vec::new(&env)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn test_types_compile() {
+        let env = Env::default();
+        let client = TypesTestContractClient::new(&env, &env.register(TypesTestContract, ()));
+        assert_eq!(client.check_status(), MembershipStatus::Active);
+        assert_eq!(client.check_tier(), TierLevel::Basic);
+        assert_eq!(client.check_period(), TimePeriod::Monthly);
+    }
+}

--- a/contracts/common_types/src/types.rs
+++ b/contracts/common_types/src/types.rs
@@ -125,3 +125,29 @@ pub struct UserAttendanceStats {
     pub date_range: DateRange,
     pub peak_hours: soroban_sdk::Vec<PeakHourData>,
 }
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum SubscriptionStatus {
+    Active,
+    Cancelled,
+    Paused,
+    Expired,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Subscription {
+    pub id: soroban_sdk::BytesN<32>,
+    pub user: soroban_sdk::Address,
+    pub payment_token: soroban_sdk::Address,
+    pub amount: i128,
+    pub status: SubscriptionStatus,
+    pub created_at: u64,
+    pub expires_at: u64,
+    pub tier_id: soroban_sdk::BytesN<32>,
+    pub billing_cycle: u64,
+    pub pause_count: u32,
+    pub paused_at: u64,
+    pub pause_reason: String,
+}

--- a/contracts/common_types/src/types.rs
+++ b/contracts/common_types/src/types.rs
@@ -1,0 +1,127 @@
+use soroban_sdk::{contracttype, String};
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum MembershipStatus {
+    Active,
+    Expired,
+    Revoked,
+    GracePeriod,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum TierLevel {
+    Basic,
+    Standard,
+    Premium,
+    Enterprise,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct TierFeature {
+    pub name: String,
+    pub enabled: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct SubscriptionTier {
+    pub level: TierLevel,
+    pub price: i128,
+    pub duration_days: u32,
+    pub features: soroban_sdk::Vec<TierFeature>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum MetadataValue {
+    Text(String),
+    Number(i128),
+    Bool(bool),
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum TierChangeStatus {
+    Pending,
+    Approved,
+    Rejected,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum TierChangeType {
+    Upgrade,
+    Downgrade,
+    Renewal,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct TierChangeRequest {
+    pub member: soroban_sdk::Address,
+    pub from_tier: TierLevel,
+    pub to_tier: TierLevel,
+    pub change_type: TierChangeType,
+    pub status: TierChangeStatus,
+    pub requested_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct TierPromotion {
+    pub tier: TierLevel,
+    pub discount_bps: u32,
+    pub valid_until: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct DateRange {
+    pub start: u64,
+    pub end: u64,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum DayPattern {
+    Weekdays,
+    Weekends,
+    Daily,
+    Custom,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct AttendanceFrequency {
+    pub pattern: DayPattern,
+    pub times_per_week: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PeakHourData {
+    pub hour: u32,
+    pub occupancy_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum TimePeriod {
+    Daily,
+    Weekly,
+    Monthly,
+    Yearly,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct UserAttendanceStats {
+    pub member: soroban_sdk::Address,
+    pub total_visits: u32,
+    pub period: TimePeriod,
+    pub date_range: DateRange,
+    pub peak_hours: soroban_sdk::Vec<PeakHourData>,
+}

--- a/contracts/hubassist_hub/Cargo.toml
+++ b/contracts/hubassist_hub/Cargo.toml
@@ -8,3 +8,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+common_types = { workspace = true }

--- a/contracts/manage_hub/Cargo.toml
+++ b/contracts/manage_hub/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "manage_hub"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+common_types = { workspace = true }

--- a/contracts/manage_hub/src/lib.rs
+++ b/contracts/manage_hub/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+mod membership_token;
+
+pub use membership_token::{
+    IssueParams, MembershipToken, MembershipTokenContract, MembershipTokenContractClient,
+    TransferParams,
+};

--- a/contracts/manage_hub/src/lib.rs
+++ b/contracts/manage_hub/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
 mod membership_token;
+mod subscription;
 
 pub use membership_token::{
     IssueParams, MembershipToken, MembershipTokenContract, MembershipTokenContractClient,
     TransferParams,
 };
+pub use subscription::{SubscriptionModule, SubscriptionModuleClient};

--- a/contracts/manage_hub/src/lib.rs
+++ b/contracts/manage_hub/src/lib.rs
@@ -2,9 +2,11 @@
 
 mod membership_token;
 mod subscription;
+mod staking;
 
 pub use membership_token::{
     IssueParams, MembershipToken, MembershipTokenContract, MembershipTokenContractClient,
     TransferParams,
 };
 pub use subscription::{SubscriptionModule, SubscriptionModuleClient};
+pub use staking::{StakeInfo, StakingConfig, StakingModule, StakingModuleClient, StakingTier};

--- a/contracts/manage_hub/src/membership_token.rs
+++ b/contracts/manage_hub/src/membership_token.rs
@@ -1,0 +1,247 @@
+use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Vec};
+
+use common_types::MembershipStatus;
+
+// ── Storage TTL constants (in ledgers; ~5s/ledger on Stellar) ──────────────
+const DAY_IN_LEDGERS: u32 = 17_280;
+const TOKEN_TTL: u32 = 365 * DAY_IN_LEDGERS;
+
+// ── Storage keys ──────────────────────────────────────────────────────────
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Token(BytesN<32>),
+    UsdcContract,
+}
+
+// ── Domain types ──────────────────────────────────────────────────────────
+#[contracttype]
+#[derive(Clone)]
+pub struct MembershipToken {
+    pub id: BytesN<32>,
+    pub user: Address,
+    pub expiry_date: u64,
+    pub status: MembershipStatus,
+}
+
+/// Parameters for batch operations.
+#[contracttype]
+#[derive(Clone)]
+pub struct IssueParams {
+    pub id: BytesN<32>,
+    pub user: Address,
+    pub expiry_date: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct TransferParams {
+    pub id: BytesN<32>,
+    pub new_user: Address,
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────
+#[contract]
+pub struct MembershipTokenContract;
+
+#[contractimpl]
+impl MembershipTokenContract {
+    // ── Admin ──────────────────────────────────────────────────────────
+
+    pub fn set_admin(env: Env, admin: Address) {
+        // First call sets admin; subsequent calls require existing admin auth.
+        if let Some(current) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::Admin)
+        {
+            current.require_auth();
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.events()
+            .publish((symbol_short!("set_admin"),), (admin,));
+    }
+
+    // ── Issue ──────────────────────────────────────────────────────────
+
+    pub fn issue_token(env: Env, id: BytesN<32>, user: Address, expiry_date: u64) {
+        Self::require_admin(&env);
+        Self::assert_no_duplicate(&env, &id);
+        Self::assert_future_expiry(&env, expiry_date);
+
+        let token = MembershipToken {
+            id: id.clone(),
+            user: user.clone(),
+            expiry_date,
+            status: MembershipStatus::Active,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(id.clone()), &token);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Token(id.clone()), TOKEN_TTL, TOKEN_TTL);
+
+        env.events()
+            .publish((symbol_short!("issued"),), (id, user, expiry_date));
+    }
+
+    // ── Read ───────────────────────────────────────────────────────────
+
+    pub fn get_token(env: Env, id: BytesN<32>) -> MembershipToken {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Token(id))
+            .expect("token not found")
+    }
+
+    // ── Transfer ───────────────────────────────────────────────────────
+
+    pub fn transfer_token(env: Env, id: BytesN<32>, new_user: Address) {
+        let mut token: MembershipToken = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token(id.clone()))
+            .expect("token not found");
+
+        token.user.require_auth();
+        assert!(
+            token.status == MembershipStatus::Active,
+            "token not transferable"
+        );
+
+        let old_user = token.user.clone();
+        token.user = new_user.clone();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(id.clone()), &token);
+
+        env.events()
+            .publish((symbol_short!("transfer"),), (id, old_user, new_user));
+    }
+
+    // ── Revoke ─────────────────────────────────────────────────────────
+
+    pub fn revoke_token(env: Env, admin: Address, id: BytesN<32>) {
+        Self::require_admin(&env);
+        admin.require_auth();
+
+        let mut token: MembershipToken = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token(id.clone()))
+            .expect("token not found");
+
+        token.status = MembershipStatus::Revoked;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(id.clone()), &token);
+
+        env.events().publish((symbol_short!("revoked"),), (id,));
+    }
+
+    // ── Renew ──────────────────────────────────────────────────────────
+
+    pub fn renew_token(env: Env, admin: Address, id: BytesN<32>, new_expiry: u64) {
+        Self::require_admin(&env);
+        admin.require_auth();
+        Self::assert_future_expiry(&env, new_expiry);
+
+        let mut token: MembershipToken = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token(id.clone()))
+            .expect("token not found");
+
+        assert!(
+            token.status != MembershipStatus::Revoked,
+            "cannot renew revoked token"
+        );
+
+        token.expiry_date = new_expiry;
+        token.status = MembershipStatus::Active;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(id.clone()), &token);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Token(id.clone()), TOKEN_TTL, TOKEN_TTL);
+
+        env.events()
+            .publish((symbol_short!("renewed"),), (id, new_expiry));
+    }
+
+    // ── Batch ──────────────────────────────────────────────────────────
+
+    pub fn batch_issue_tokens(env: Env, params_vec: Vec<IssueParams>) {
+        Self::require_admin(&env);
+        for p in params_vec.iter() {
+            Self::assert_no_duplicate(&env, &p.id);
+            Self::assert_future_expiry(&env, p.expiry_date);
+            let token = MembershipToken {
+                id: p.id.clone(),
+                user: p.user.clone(),
+                expiry_date: p.expiry_date,
+                status: MembershipStatus::Active,
+            };
+            env.storage()
+                .persistent()
+                .set(&DataKey::Token(p.id.clone()), &token);
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::Token(p.id.clone()), TOKEN_TTL, TOKEN_TTL);
+            env.events()
+                .publish((symbol_short!("issued"),), (p.id.clone(), p.user.clone(), p.expiry_date));
+        }
+    }
+
+    pub fn batch_transfer_tokens(env: Env, params_vec: Vec<TransferParams>) {
+        for p in params_vec.iter() {
+            let mut token: MembershipToken = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Token(p.id.clone()))
+                .expect("token not found");
+
+            token.user.require_auth();
+            assert!(
+                token.status == MembershipStatus::Active,
+                "token not transferable"
+            );
+
+            let old_user = token.user.clone();
+            token.user = p.new_user.clone();
+            env.storage()
+                .persistent()
+                .set(&DataKey::Token(p.id.clone()), &token);
+            env.events()
+                .publish((symbol_short!("transfer"),), (p.id.clone(), old_user, p.new_user.clone()));
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    fn require_admin(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("admin not set");
+        admin.require_auth();
+    }
+
+    fn assert_no_duplicate(env: &Env, id: &BytesN<32>) {
+        assert!(
+            !env.storage().persistent().has(&DataKey::Token(id.clone())),
+            "token id already exists"
+        );
+    }
+
+    fn assert_future_expiry(env: &Env, expiry_date: u64) {
+        assert!(
+            expiry_date > env.ledger().timestamp(),
+            "expiry must be in the future"
+        );
+    }
+}

--- a/contracts/manage_hub/src/staking.rs
+++ b/contracts/manage_hub/src/staking.rs
@@ -1,0 +1,277 @@
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, Env, String, Vec};
+
+// ── TTL constant (~30 days at ~5s/ledger) ─────────────────────────────────
+const STAKE_TTL_LEDGERS: u32 = 30 * 17_280;
+
+// ── Storage keys ──────────────────────────────────────────────────────────
+#[contracttype]
+#[derive(Clone)]
+pub enum StakeKey {
+    Admin,
+    Config,
+    Tier(BytesN<32>),
+    TierList,
+    Stake(Address),
+    StakingToken,
+}
+
+// ── Domain types ──────────────────────────────────────────────────────────
+#[contracttype]
+#[derive(Clone)]
+pub struct StakingConfig {
+    pub min_stake_amount: i128,
+    pub max_stake_amount: i128,
+    pub emergency_unstake_penalty_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct StakingTier {
+    pub id: BytesN<32>,
+    pub name: String,
+    pub min_amount: i128,
+    pub base_rate_bps: u32,
+    pub reward_multiplier_bps: u32,
+    pub lock_period_seconds: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct StakeInfo {
+    pub staker: Address,
+    pub amount: i128,
+    pub tier_id: BytesN<32>,
+    pub staked_at: u64,
+    pub claimed_rewards: i128,
+    pub emergency_unstaked: bool,
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────
+#[contract]
+pub struct StakingModule;
+
+#[contractimpl]
+impl StakingModule {
+    // ── Admin setup ────────────────────────────────────────────────────
+
+    pub fn set_staking_config(env: Env, admin: Address, config: StakingConfig) {
+        admin.require_auth();
+        env.storage().instance().set(&StakeKey::Admin, &admin);
+        env.storage().persistent().set(&StakeKey::Config, &config);
+        env.events()
+            .publish((symbol_short!("cfg_set"),), (admin,));
+    }
+
+    pub fn add_staking_tier(env: Env, admin: Address, tier: StakingTier) {
+        Self::require_admin(&env, &admin);
+        let tier_id = tier.id.clone();
+        env.storage()
+            .persistent()
+            .set(&StakeKey::Tier(tier_id.clone()), &tier);
+
+        let mut list: Vec<BytesN<32>> = env
+            .storage()
+            .persistent()
+            .get(&StakeKey::TierList)
+            .unwrap_or(Vec::new(&env));
+        list.push_back(tier_id.clone());
+        env.storage().persistent().set(&StakeKey::TierList, &list);
+
+        env.events()
+            .publish((symbol_short!("tier_add"),), (tier_id,));
+    }
+
+    // ── Read ───────────────────────────────────────────────────────────
+
+    pub fn get_staking_tier(env: Env, tier_id: BytesN<32>) -> StakingTier {
+        env.storage()
+            .persistent()
+            .get(&StakeKey::Tier(tier_id))
+            .expect("tier not found")
+    }
+
+    pub fn list_staking_tiers(env: Env) -> Vec<StakingTier> {
+        let ids: Vec<BytesN<32>> = env
+            .storage()
+            .persistent()
+            .get(&StakeKey::TierList)
+            .unwrap_or(Vec::new(&env));
+        let mut tiers: Vec<StakingTier> = Vec::new(&env);
+        for id in ids.iter() {
+            if let Some(t) = env.storage().persistent().get(&StakeKey::Tier(id)) {
+                tiers.push_back(t);
+            }
+        }
+        tiers
+    }
+
+    pub fn get_stake(env: Env, staker: Address) -> StakeInfo {
+        env.storage()
+            .persistent()
+            .get(&StakeKey::Stake(staker))
+            .expect("no active stake")
+    }
+
+    // ── Stake ──────────────────────────────────────────────────────────
+
+    pub fn stake(env: Env, staker: Address, amount: i128, tier_id: BytesN<32>) {
+        staker.require_auth();
+
+        let config: StakingConfig = env
+            .storage()
+            .persistent()
+            .get(&StakeKey::Config)
+            .expect("staking not configured");
+        assert!(amount >= config.min_stake_amount, "below min stake");
+        assert!(amount <= config.max_stake_amount, "above max stake");
+
+        let tier: StakingTier = env
+            .storage()
+            .persistent()
+            .get(&StakeKey::Tier(tier_id.clone()))
+            .expect("tier not found");
+        assert!(amount >= tier.min_amount, "below tier min amount");
+
+        // Must not already have an active stake.
+        assert!(
+            !env.storage()
+                .persistent()
+                .has(&StakeKey::Stake(staker.clone())),
+            "already staking"
+        );
+
+        let staking_token: Address = env
+            .storage()
+            .instance()
+            .get(&StakeKey::StakingToken)
+            .expect("staking token not set");
+        token::Client::new(&env, &staking_token).transfer(
+            &staker,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let info = StakeInfo {
+            staker: staker.clone(),
+            amount,
+            tier_id: tier_id.clone(),
+            staked_at: env.ledger().timestamp(),
+            claimed_rewards: 0,
+            emergency_unstaked: false,
+        };
+        env.storage()
+            .persistent()
+            .set(&StakeKey::Stake(staker.clone()), &info);
+        env.storage()
+            .persistent()
+            .extend_ttl(&StakeKey::Stake(staker.clone()), STAKE_TTL_LEDGERS, STAKE_TTL_LEDGERS);
+
+        env.events()
+            .publish((symbol_short!("staked"),), (staker, amount, tier_id));
+    }
+
+    // ── Unstake ────────────────────────────────────────────────────────
+
+    pub fn unstake(env: Env, staker: Address) {
+        staker.require_auth();
+        let info: StakeInfo = env
+            .storage()
+            .persistent()
+            .get(&StakeKey::Stake(staker.clone()))
+            .expect("no active stake");
+
+        let tier: StakingTier = env
+            .storage()
+            .persistent()
+            .get(&StakeKey::Tier(info.tier_id.clone()))
+            .expect("tier not found");
+
+        let now = env.ledger().timestamp();
+        assert!(
+            now >= info.staked_at + tier.lock_period_seconds,
+            "lock period not elapsed"
+        );
+
+        let rewards = Self::calc_rewards(&info, &tier, now);
+        let payout = info.amount + rewards;
+
+        let staking_token: Address = env
+            .storage()
+            .instance()
+            .get(&StakeKey::StakingToken)
+            .expect("staking token not set");
+        token::Client::new(&env, &staking_token).transfer(
+            &env.current_contract_address(),
+            &staker,
+            &payout,
+        );
+
+        env.storage()
+            .persistent()
+            .remove(&StakeKey::Stake(staker.clone()));
+        env.events()
+            .publish((symbol_short!("unstaked"),), (staker, payout));
+    }
+
+    // ── Emergency unstake ──────────────────────────────────────────────
+
+    pub fn emergency_unstake(env: Env, staker: Address) {
+        staker.require_auth();
+        let mut info: StakeInfo = env
+            .storage()
+            .persistent()
+            .get(&StakeKey::Stake(staker.clone()))
+            .expect("no active stake");
+
+        let config: StakingConfig = env
+            .storage()
+            .persistent()
+            .get(&StakeKey::Config)
+            .expect("staking not configured");
+
+        let penalty = info.amount * config.emergency_unstake_penalty_bps as i128 / 10_000;
+        let payout = info.amount - penalty;
+
+        let staking_token: Address = env
+            .storage()
+            .instance()
+            .get(&StakeKey::StakingToken)
+            .expect("staking token not set");
+        token::Client::new(&env, &staking_token).transfer(
+            &env.current_contract_address(),
+            &staker,
+            &payout,
+        );
+
+        info.emergency_unstaked = true;
+        env.storage()
+            .persistent()
+            .remove(&StakeKey::Stake(staker.clone()));
+        env.events()
+            .publish((symbol_short!("emrg_ust"),), (staker, payout, penalty));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    fn require_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StakeKey::Admin)
+            .expect("admin not set");
+        assert!(admin == *caller, "not admin");
+        caller.require_auth();
+    }
+
+    /// Simple linear reward: principal * base_rate_bps * multiplier * elapsed / year / 10_000^2
+    fn calc_rewards(info: &StakeInfo, tier: &StakingTier, now: u64) -> i128 {
+        let elapsed = (now - info.staked_at) as i128;
+        let year_secs: i128 = 365 * 24 * 3600;
+        info.amount
+            * tier.base_rate_bps as i128
+            * tier.reward_multiplier_bps as i128
+            * elapsed
+            / year_secs
+            / 100_000_000 // 10_000 * 10_000
+    }
+}

--- a/contracts/manage_hub/src/subscription.rs
+++ b/contracts/manage_hub/src/subscription.rs
@@ -1,0 +1,190 @@
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, Env, String};
+
+use common_types::{Subscription, SubscriptionStatus, SubscriptionTier};
+
+// ── Pause policy constants ─────────────────────────────────────────────────
+const MAX_PAUSES: u32 = 3;
+const MIN_PAUSE_INTERVAL: u64 = 7 * 24 * 3600; // 7 days in seconds
+
+// ── Storage keys ──────────────────────────────────────────────────────────
+#[contracttype]
+#[derive(Clone)]
+pub enum SubKey {
+    Subscription(Address),
+    Tier(BytesN<32>),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────
+#[contract]
+pub struct SubscriptionModule;
+
+#[contractimpl]
+impl SubscriptionModule {
+    /// Register a tier so subscriptions can validate against it.
+    pub fn set_tier(env: Env, tier_id: BytesN<32>, tier: SubscriptionTier) {
+        env.storage().persistent().set(&SubKey::Tier(tier_id), &tier);
+    }
+
+    // ── Create ─────────────────────────────────────────────────────────
+
+    pub fn create_subscription(
+        env: Env,
+        user: Address,
+        payment_token: Address,
+        amount: i128,
+        tier_id: BytesN<32>,
+        billing_cycle: u64,
+    ) -> Subscription {
+        user.require_auth();
+
+        // Validate amount against tier price.
+        let tier: SubscriptionTier = env
+            .storage()
+            .persistent()
+            .get(&SubKey::Tier(tier_id.clone()))
+            .expect("tier not found");
+        assert!(amount >= tier.price, "payment amount below tier price");
+
+        // Transfer USDC from user to contract.
+        token::Client::new(&env, &payment_token).transfer(
+            &user,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let now = env.ledger().timestamp();
+        let sub = Subscription {
+            id: env.crypto().sha256(&env.ledger().sequence().to_xdr(&env)).into(),
+            user: user.clone(),
+            payment_token: payment_token.clone(),
+            amount,
+            status: SubscriptionStatus::Active,
+            created_at: now,
+            expires_at: now + billing_cycle,
+            tier_id: tier_id.clone(),
+            billing_cycle,
+            pause_count: 0,
+            paused_at: 0,
+            pause_reason: String::from_str(&env, ""),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&SubKey::Subscription(user.clone()), &sub);
+
+        env.events()
+            .publish((symbol_short!("sub_new"),), (user, tier_id, amount));
+
+        sub
+    }
+
+    // ── Read ───────────────────────────────────────────────────────────
+
+    pub fn get_subscription(env: Env, user: Address) -> Subscription {
+        env.storage()
+            .persistent()
+            .get(&SubKey::Subscription(user))
+            .expect("subscription not found")
+    }
+
+    // ── Cancel ─────────────────────────────────────────────────────────
+
+    pub fn cancel_subscription(env: Env, user: Address) {
+        user.require_auth();
+        let mut sub = Self::load(&env, &user);
+        assert!(
+            sub.status == SubscriptionStatus::Active
+                || sub.status == SubscriptionStatus::Paused,
+            "subscription not cancellable"
+        );
+        sub.status = SubscriptionStatus::Cancelled;
+        Self::save(&env, &user, &sub);
+        env.events().publish((symbol_short!("sub_cncl"),), (user,));
+    }
+
+    // ── Pause ──────────────────────────────────────────────────────────
+
+    pub fn pause_subscription(env: Env, user: Address, reason: String) {
+        user.require_auth();
+        let mut sub = Self::load(&env, &user);
+        assert!(
+            sub.status == SubscriptionStatus::Active,
+            "only active subscriptions can be paused"
+        );
+        assert!(sub.pause_count < MAX_PAUSES, "max pauses reached");
+
+        let now = env.ledger().timestamp();
+        if sub.paused_at > 0 {
+            assert!(
+                now >= sub.paused_at + MIN_PAUSE_INTERVAL,
+                "min interval between pauses not met"
+            );
+        }
+
+        sub.status = SubscriptionStatus::Paused;
+        sub.paused_at = now;
+        sub.pause_reason = reason.clone();
+        sub.pause_count += 1;
+        Self::save(&env, &user, &sub);
+        env.events()
+            .publish((symbol_short!("sub_paus"),), (user, reason));
+    }
+
+    // ── Resume ─────────────────────────────────────────────────────────
+
+    pub fn resume_subscription(env: Env, user: Address) {
+        user.require_auth();
+        let mut sub = Self::load(&env, &user);
+        assert!(
+            sub.status == SubscriptionStatus::Paused,
+            "subscription is not paused"
+        );
+        // Extend expiry by the time spent paused.
+        let paused_duration = env.ledger().timestamp() - sub.paused_at;
+        sub.expires_at += paused_duration;
+        sub.status = SubscriptionStatus::Active;
+        sub.paused_at = 0;
+        sub.pause_reason = String::from_str(&env, "");
+        Self::save(&env, &user, &sub);
+        env.events().publish((symbol_short!("sub_res"),), (user,));
+    }
+
+    // ── Renew ──────────────────────────────────────────────────────────
+
+    pub fn renew_subscription(env: Env, user: Address) {
+        user.require_auth();
+        let mut sub = Self::load(&env, &user);
+        assert!(
+            sub.status != SubscriptionStatus::Cancelled,
+            "cannot renew cancelled subscription"
+        );
+
+        // Collect payment again.
+        token::Client::new(&env, &sub.payment_token).transfer(
+            &user,
+            &env.current_contract_address(),
+            &sub.amount,
+        );
+
+        sub.expires_at += sub.billing_cycle;
+        sub.status = SubscriptionStatus::Active;
+        Self::save(&env, &user, &sub);
+        env.events()
+            .publish((symbol_short!("sub_renw"),), (user, sub.expires_at));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    fn load(env: &Env, user: &Address) -> Subscription {
+        env.storage()
+            .persistent()
+            .get(&SubKey::Subscription(user.clone()))
+            .expect("subscription not found")
+    }
+
+    fn save(env: &Env, user: &Address, sub: &Subscription) {
+        env.storage()
+            .persistent()
+            .set(&SubKey::Subscription(user.clone()), sub);
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements four Soroban smart contract tasks, laying the shared type foundation and three core modules of the `manage_hub` contract.

---

### #100 — `common_types` library crate

- Created `contracts/common_types/` as a shared `rlib` crate used across all contracts
- `src/types.rs` — 15 shared `#[contracttype]` types:
  `MembershipStatus`, `SubscriptionTier`, `TierLevel`, `TierFeature`, `MetadataValue`,
  `TierChangeRequest`, `TierChangeStatus`, `TierChangeType`, `TierPromotion`,
  `AttendanceFrequency`, `DateRange`, `DayPattern`, `PeakHourData`, `TimePeriod`,
  `UserAttendanceStats`
- `src/lib.rs` — re-exports all types; gates `test_contract` behind `test`/`testutils`
- `src/test_contract.rs` — minimal Soroban contract verifying shared types compile
- Added `common_types` to workspace members and `workspace.dependencies`
- Updated `workspace_booking` and `hubassist_hub` to depend on `common_types`

---

### #101 — `manage_hub`: membership token module

- Created `contracts/manage_hub/src/membership_token.rs`
- `MembershipTokenContract` with 8 methods: `set_admin`, `issue_token`, `get_token`,
  `transfer_token`, `revoke_token`, `renew_token`, `batch_issue_tokens`, `batch_transfer_tokens`
- `DataKey` enum: `Admin`, `Token(BytesN<32>)`, `UsdcContract`
- Persistent storage with `TOKEN_TTL = 365 days` in ledgers; TTL extended on issue and renew
- Events emitted on every mutation: `set_admin`, `issued`, `transfer`, `revoked`, `renewed`
- Validations: future expiry check, duplicate token ID guard, admin auth on all write ops

---

### #102 — `manage_hub`: subscription module

- Added `SubscriptionStatus` enum and `Subscription` struct (12 fields) to `common_types`
- Created `contracts/manage_hub/src/subscription.rs`
- `SubscriptionModule` with 6 methods: `create_subscription`, `get_subscription`,
  `cancel_subscription`, `pause_subscription`, `resume_subscription`, `renew_subscription`
- Payment validated against stored `SubscriptionTier` price; USDC transferred via `token::Client`
  on create and renew
- Pause policy: max 3 pauses, 7-day minimum interval between pauses
- Resume extends `expires_at` by exact paused duration
- Events: `sub_new`, `sub_cncl`, `sub_paus`, `sub_res`, `sub_renw`

---

### #104 — `manage_hub`: staking module

- Created `contracts/manage_hub/src/staking.rs`
- `StakingModule` with 8 methods: `set_staking_config`, `add_staking_tier`, `get_staking_tier`,
  `list_staking_tiers`, `stake`, `unstake`, `emergency_unstake`, `get_stake`
- `StakingConfig`: `min_stake_amount`, `max_stake_amount`, `emergency_unstake_penalty_bps`
- `StakingTier`: `id`, `name`, `min_amount`, `base_rate_bps`, `reward_multiplier_bps`, `lock_period_seconds`
- `StakeInfo`: `staker`, `amount`, `tier_id`, `staked_at`, `claimed_rewards`, `emergency_unstaked`
- `STAKE_TTL_LEDGERS = 30 * 17_280` (~30 days); TTL extended on stake
- Lock period enforced on normal unstake; emergency unstake skips lock but applies penalty
- Linear reward formula: `principal × base_rate_bps × multiplier_bps × elapsed / year / 10_000²`
- Tier list maintained via `TierList` key holding `Vec<BytesN<32>>`
- Events: `cfg_set`, `tier_add`, `staked`, `unstaked`, `emrg_ust`

---

Closes #100
Closes #101
Closes #102
Closes #104