### PR TITLE
feat: create base UI component library

### DIFF
--- a/frontend/src/components/bookings/BookingActions.tsx
+++ b/frontend/src/components/bookings/BookingActions.tsx
@@ -38,7 +38,7 @@ export function BookingActions({ booking, isAdmin }: Props) {
     <div className="flex gap-2 flex-wrap">
       {isAdmin && isPending && (
         <Button
-          variant="default"
+          variant="primary"
           onClick={() => confirm.mutate()}
           disabled={confirm.isPending}
         >

--- a/frontend/src/components/layout/Container.tsx
+++ b/frontend/src/components/layout/Container.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface ContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  as?: React.ElementType;
+}
+
+export function Container({ as: Tag = "div", className, children, ...props }: ContainerProps) {
+  return (
+    <Tag className={cn("mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8", className)} {...props}>
+      {children}
+    </Tag>
+  );
+}

--- a/frontend/src/components/ui/Alert.tsx
+++ b/frontend/src/components/ui/Alert.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { CheckCircle, XCircle, AlertTriangle, Info, X } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+type AlertVariant = "success" | "error" | "warning" | "info";
+
+interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: AlertVariant;
+  onDismiss?: () => void;
+}
+
+const config: Record<AlertVariant, { icon: React.ElementType; classes: string }> = {
+  success: { icon: CheckCircle, classes: "bg-[#EAF3E8] border-[#A8C5A0] text-[#1A1A1A]" },
+  error:   { icon: XCircle,     classes: "bg-[#F9EDE8] border-[#D4916E] text-[#1A1A1A]" },
+  warning: { icon: AlertTriangle,classes: "bg-[#FDF5E6] border-[#D4B96E] text-[#1A1A1A]" },
+  info:    { icon: Info,         classes: "bg-[#EAF0F9] border-[#8AAAD4] text-[#1A1A1A]" },
+};
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant = "info", onDismiss, children, ...props }, ref) => {
+    const { icon: Icon, classes } = config[variant];
+    return (
+      <div
+        ref={ref}
+        role="alert"
+        className={cn("flex items-start gap-3 rounded-2xl border px-4 py-3 text-sm", classes, className)}
+        {...props}
+      >
+        <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="flex-1">{children}</div>
+        {onDismiss && (
+          <button onClick={onDismiss} aria-label="Dismiss" className="shrink-0 opacity-60 hover:opacity-100">
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    );
+  }
+);
+Alert.displayName = "Alert";
+
+export { Alert };
+export type { AlertVariant };

--- a/frontend/src/components/ui/BreadCrumb.tsx
+++ b/frontend/src/components/ui/BreadCrumb.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+interface BreadCrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadCrumbProps {
+  items: BreadCrumbItem[];
+  className?: string;
+}
+
+export function BreadCrumb({ items, className }: BreadCrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className={cn("flex items-center gap-1 text-sm", className)}>
+      {items.map((item, i) => {
+        const isLast = i === items.length - 1;
+        return (
+          <React.Fragment key={i}>
+            {i > 0 && <ChevronRight className="h-3.5 w-3.5 text-[#6B6B6B]" />}
+            {isLast || !item.href ? (
+              <span className={cn(isLast ? "text-[#1A1A1A] font-medium" : "text-[#6B6B6B]")}>
+                {item.label}
+              </span>
+            ) : (
+              <Link href={item.href} className="text-[#6B6B6B] hover:text-[#1A1A1A] transition-colors">
+                {item.label}
+              </Link>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,41 +1,45 @@
-import * as React from "react"
-
-import { cn } from "@/lib/cn"
+import * as React from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/cn";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link"
-  size?: "default" | "sm" | "lg" | "icon"
+  variant?: "primary" | "secondary" | "outline" | "ghost" | "destructive";
+  size?: "sm" | "md" | "lg";
+  loading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", size = "default", ...props }, ref) => {
-    const baseClasses = "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+  ({ className, variant = "primary", size = "md", loading, disabled, children, ...props }, ref) => {
+    const base =
+      "inline-flex items-center justify-center font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-[#1A1A1A] focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 rounded-full";
 
-    const variantClasses = {
-      default: "bg-primary text-primary-foreground hover:bg-primary/90",
-      destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-      outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-      secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-      ghost: "hover:bg-accent hover:text-accent-foreground",
-      link: "text-primary underline-offset-4 hover:underline",
-    }
+    const variants = {
+      primary: "bg-[#1A1A1A] text-[#F3EBE2] hover:bg-[#3D3D3D]",
+      secondary: "bg-[#D7CFC6] text-[#1A1A1A] hover:bg-[#C5BEB6]",
+      outline: "border border-[#D7CFC6] bg-transparent text-[#1A1A1A] hover:bg-[#EDE2D6]",
+      ghost: "bg-transparent text-[#1A1A1A] hover:bg-[#EDE2D6]",
+      destructive: "bg-[#D4916E] text-white hover:bg-[#c07a58]",
+    };
 
-    const sizeClasses = {
-      default: "h-10 px-4 py-2",
-      sm: "h-9 rounded-md px-3",
-      lg: "h-11 rounded-md px-8",
-      icon: "h-10 w-10",
-    }
+    const sizes = {
+      sm: "h-8 px-3 text-xs",
+      md: "h-10 px-5 text-sm",
+      lg: "h-12 px-7 text-base",
+    };
 
     return (
       <button
-        className={cn(baseClasses, variantClasses[variant], sizeClasses[size], className)}
         ref={ref}
+        disabled={disabled || loading}
+        className={cn(base, variants[variant], sizes[size], className)}
         {...props}
-      />
-    )
+      >
+        {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        {children}
+      </button>
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = "Button";
 
-export { Button }
+export { Button };

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-2xl bg-[#F3EBE2] shadow-sm", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("px-6 pt-6 pb-4 border-b border-[#D7CFC6]", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardBody = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("px-6 py-4", className)} {...props} />
+  )
+);
+CardBody.displayName = "CardBody";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("px-6 pb-6 pt-4 border-t border-[#D7CFC6]", className)} {...props} />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardBody, CardFooter };

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,24 +1,50 @@
-import * as React from "react"
+import * as React from "react";
+import { cn } from "@/lib/cn";
 
-import { cn } from "@/lib/cn"
-
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  helperText?: string;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, label, error, helperText, leftIcon, rightIcon, id, ...props }, ref) => {
+    const inputId = id ?? label?.toLowerCase().replace(/\s+/g, "-");
     return (
-      <input
-        type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-          className
+      <div className="flex flex-col gap-1.5">
+        {label && (
+          <label htmlFor={inputId} className="text-xs font-semibold tracking-[0.1em] text-[#6B6B6B]">
+            {label.toUpperCase()}
+          </label>
         )}
-        ref={ref}
-        {...props}
-      />
-    )
+        <div className="relative flex items-center">
+          {leftIcon && (
+            <span className="absolute left-4 text-[#6B6B6B]">{leftIcon}</span>
+          )}
+          <input
+            id={inputId}
+            ref={ref}
+            className={cn(
+              "w-full rounded-full border border-[#D7CFC6] bg-[#EDE2D6] px-4 py-3 text-sm text-[#1A1A1A] placeholder:text-[#6B6B6B] focus:outline-none focus:ring-2 focus:ring-[#1A1A1A] disabled:cursor-not-allowed disabled:opacity-50",
+              leftIcon && "pl-10",
+              rightIcon && "pr-10",
+              error && "border-[#D4916E] focus:ring-[#D4916E]",
+              className
+            )}
+            {...props}
+          />
+          {rightIcon && (
+            <span className="absolute right-4 text-[#6B6B6B]">{rightIcon}</span>
+          )}
+        </div>
+        {error && <p className="text-xs text-[#D4916E]">{error}</p>}
+        {!error && helperText && <p className="text-xs text-[#6B6B6B]">{helperText}</p>}
+      </div>
+    );
   }
-)
-Input.displayName = "Input"
+);
+Input.displayName = "Input";
 
-export { Input }
+export { Input };

--- a/frontend/src/components/ui/PageTitle.tsx
+++ b/frontend/src/components/ui/PageTitle.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { BreadCrumb } from "./BreadCrumb";
+
+interface BreadCrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface PageTitleProps {
+  title: string;
+  subtitle?: string;
+  breadcrumb?: BreadCrumbItem[];
+  className?: string;
+}
+
+export function PageTitle({ title, subtitle, breadcrumb, className }: PageTitleProps) {
+  return (
+    <div className={cn("flex flex-col gap-1", className)}>
+      {breadcrumb && <BreadCrumb items={breadcrumb} className="mb-1" />}
+      <h1 className="text-2xl font-semibold text-[#1A1A1A]">{title}</h1>
+      {subtitle && <p className="text-sm text-[#6B6B6B]">{subtitle}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  pageSize?: number;
+  pageSizeOptions?: number[];
+  onPageChange: (page: number) => void;
+  onPageSizeChange?: (size: number) => void;
+  className?: string;
+}
+
+export function Pagination({
+  page,
+  totalPages,
+  pageSize,
+  pageSizeOptions = [10, 20, 50],
+  onPageChange,
+  onPageSizeChange,
+  className,
+}: PaginationProps) {
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  const btnBase =
+    "inline-flex h-8 w-8 items-center justify-center rounded-full text-sm transition-colors disabled:opacity-40";
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <button
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        aria-label="Previous page"
+        className={cn(btnBase, "border border-[#D7CFC6] hover:bg-[#EDE2D6]")}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+
+      {pages.map((p) => (
+        <button
+          key={p}
+          onClick={() => onPageChange(p)}
+          aria-current={p === page ? "page" : undefined}
+          className={cn(
+            btnBase,
+            p === page
+              ? "bg-[#1A1A1A] text-[#F3EBE2]"
+              : "border border-[#D7CFC6] hover:bg-[#EDE2D6]"
+          )}
+        >
+          {p}
+        </button>
+      ))}
+
+      <button
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        aria-label="Next page"
+        className={cn(btnBase, "border border-[#D7CFC6] hover:bg-[#EDE2D6]")}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+
+      {onPageSizeChange && pageSize && (
+        <select
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(Number(e.target.value))}
+          className="ml-2 rounded-full border border-[#D7CFC6] bg-[#EDE2D6] px-3 py-1 text-sm text-[#1A1A1A] focus:outline-none"
+        >
+          {pageSizeOptions.map((s) => (
+            <option key={s} value={s}>{s} / page</option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/ToggleBar.tsx
+++ b/frontend/src/components/ui/ToggleBar.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface ToggleOption<T extends string> {
+  label: string;
+  value: T;
+}
+
+interface ToggleBarProps<T extends string> {
+  options: ToggleOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  className?: string;
+}
+
+export function ToggleBar<T extends string>({ options, value, onChange, className }: ToggleBarProps<T>) {
+  return (
+    <div
+      role="tablist"
+      className={cn("inline-flex rounded-full bg-[#D7CFC6] p-1 gap-1", className)}
+    >
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          role="tab"
+          aria-selected={opt.value === value}
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+            opt.value === value
+              ? "bg-[#1A1A1A] text-[#F3EBE2]"
+              : "text-[#6B6B6B] hover:text-[#1A1A1A]"
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/utils/cn.ts
+++ b/frontend/src/utils/cn.ts
@@ -1,0 +1,1 @@
+export { cn } from "@/lib/cn";


### PR DESCRIPTION
- Button: variants (primary, secondary, outline, ghost, destructive), sizes (sm, md, lg), loading state
- Input: label, error, helperText, leftIcon, rightIcon slots
- Card: CardHeader, CardBody, CardFooter slots
- Alert: variants (success, error, warning, info) with icon and dismiss
- Pagination: page buttons, prev/next, items per page selector
- BreadCrumb: navigation from array of { label, href }
- PageTitle: heading with optional subtitle and breadcrumb
- ToggleBar: tab-style toggle between options
- Container: max-width wrapper with responsive padding
- utils/cn.ts: clsx + tailwind-merge utility

Closes #82 