### PR TITLE
feat: add Next.js middleware for route protection

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const publicRoutes = [
+  "/",
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/reset-password",
+  "/verify-otp",
+  "/contact",
+  "/privacy-policy",
+  "/terms-of-service",
+];
+
+const protectedRoutes: Record<string, string | null> = {
+  "/dashboard": null,
+  "/profile": null,
+  "/settings": null,
+  "/admin": "admin",
+};
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const token = request.cookies.get("token")?.value;
+
+  // Redirect authenticated users away from login/register
+  if (token && (pathname === "/login" || pathname === "/register")) {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  // Check if route is protected
+  const matchedRoute = Object.keys(protectedRoutes).find(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  );
+
+  if (matchedRoute) {
+    if (!token) {
+      const loginUrl = new URL("/login", request.url);
+      loginUrl.searchParams.set("redirect", pathname);
+      return NextResponse.redirect(loginUrl);
+    }
+
+    const requiredRole = protectedRoutes[matchedRoute];
+    if (requiredRole) {
+      try {
+        const payload = JSON.parse(atob(token.split(".")[1]));
+        if (payload.role !== requiredRole) {
+          return NextResponse.redirect(new URL("/dashboard", request.url));
+        }
+      } catch {
+        const loginUrl = new URL("/login", request.url);
+        loginUrl.searchParams.set("redirect", pathname);
+        return NextResponse.redirect(loginUrl);
+      }
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|api/).*)",
+  ],
+};


### PR DESCRIPTION
- Define publicRoutes: /, /login, /register, /forgot-password, /reset-password, /verify-otp, /contact, /privacy-policy, /terms-of-service
- Define protectedRoutes with role requirements: /dashboard, /profile, /settings (any auth), /admin (admin role)
- Redirect unauthenticated users to /login?redirect= for protected routes
- Redirect authenticated users away from /login and /register to /dashboard
- Configure matcher to exclude _next/static, _next/image, favicon.ico, and API routes

Closes #80 