### PR TITLE
feat: add Zod validation schemas for auth, booking, and profile

### DIFF
--- a/frontend/src/lib/schemas/auth.ts
+++ b/frontend/src/lib/schemas/auth.ts
@@ -1,0 +1,4 @@
+export * from "./loginSchema";
+export * from "./registerSchema";
+export * from "./forgotPasswordSchema";
+export * from "./resetPasswordSchema";

--- a/frontend/src/lib/schemas/bookingSchema.ts
+++ b/frontend/src/lib/schemas/bookingSchema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const bookingSchema = z
+  .object({
+    workspaceId: z.string().min(1, "Workspace is required"),
+    startTime: z.string().min(1, "Start time is required"),
+    endTime: z.string().min(1, "End time is required"),
+  })
+  .refine((d) => new Date(d.endTime) > new Date(d.startTime), {
+    message: "End time must be after start time",
+    path: ["endTime"],
+  });
+
+export type BookingFormValues = z.infer<typeof bookingSchema>;

--- a/frontend/src/lib/schemas/forgotPasswordSchema.ts
+++ b/frontend/src/lib/schemas/forgotPasswordSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().email("Enter a valid email address"),
+});
+
+export type ForgotPasswordValues = z.infer<typeof forgotPasswordSchema>;

--- a/frontend/src/lib/schemas/profileSchema.ts
+++ b/frontend/src/lib/schemas/profileSchema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const profileSchema = z.object({
+  firstname: z.string().min(1, "First name is required"),
+  lastname: z.string().min(1, "Last name is required"),
+  stellarPublicKey: z
+    .string()
+    .optional()
+    .refine((v) => !v || /^G[A-Z2-7]{55}$/.test(v), {
+      message: "Enter a valid Stellar public key (starts with G, 56 chars)",
+    }),
+});
+
+export type ProfileFormValues = z.infer<typeof profileSchema>;


### PR DESCRIPTION
- Add forgotPasswordSchema (email)
- Add auth.ts barrel export for all auth schemas
- Add bookingSchema (workspaceId, startTime, endTime with endTime > startTime)
- Add profileSchema (firstname, lastname, optional stellarPublicKey)
- Export inferred TypeScript types from each schema

Closes #89 