### PR TITLE
feature:Write integration tests for React Query hooks

### DIFF
--- a/frontend/__tests__/lib/react-query/README.md
+++ b/frontend/__tests__/lib/react-query/README.md
@@ -1,0 +1,242 @@
+# React Query Mutation Hooks Integration Tests
+
+This directory contains comprehensive integration tests for React Query mutation hooks used in the authentication flow.
+
+## Test Files
+
+### `useLoginUser.test.tsx`
+Tests for the login mutation hook that handles user authentication.
+
+**Coverage:**
+- ✅ On success: calls `authStore.login()` with response data
+- ✅ On success: sets data on successful login
+- ✅ On success: handles login without user data
+- ✅ On error: sets error state on failed login
+- ✅ On error: does not call `authStore.login()` on error
+- ✅ On error: handles 401 unauthorized error
+- ✅ On error: handles 500 server error
+- ✅ Mutation state: tracks `isPending` correctly
+- ✅ Mutation state: uses correct mutation key
+- ✅ Edge cases: handles rapid successive mutations
+- ✅ Edge cases: handles empty response gracefully
+
+### `useRegisterUser.test.tsx`
+Tests for the registration mutation hook that handles user registration.
+
+**Coverage:**
+- ✅ On success: calls `authStore.register()` when `access_token` is present
+- ✅ On success: does not call `authStore.register()` when `access_token` is missing
+- ✅ On success: sets data on successful registration
+- ✅ On success: handles registration with user data but no token
+- ✅ On error: sets error state on failed registration
+- ✅ On error: displays error message on validation failure
+- ✅ On error: handles 409 conflict error (email exists)
+- ✅ On error: handles 400 bad request error
+- ✅ On error: handles network error
+- ✅ Mutation state: tracks `isPending` correctly
+- ✅ Mutation state: uses correct mutation key
+- ✅ Edge cases: handles special characters in names
+- ✅ Edge cases: handles long email addresses
+- ✅ Edge cases: handles rapid successive registrations
+
+### `useForgotPassword.test.tsx`
+Tests for the forgot password mutation hook that handles password reset requests.
+
+**Coverage:**
+- ✅ On success: shows success message on successful request
+- ✅ On success: sets data with success message
+- ✅ On success: handles success response with additional metadata
+- ✅ On success: handles multiple successful requests
+- ✅ On error: shows error message on failed request
+- ✅ On error: handles 404 not found error
+- ✅ On error: handles 400 bad request error (invalid email)
+- ✅ On error: handles 429 too many requests error
+- ✅ On error: handles 500 server error
+- ✅ On error: handles network error
+- ✅ On error: handles timeout error
+- ✅ Mutation state: tracks `isPending` correctly
+- ✅ Mutation state: uses correct mutation key
+- ✅ Mutation state: resets error state on new mutation
+- ✅ Edge cases: handles email with special characters
+- ✅ Edge cases: handles email with subdomain
+- ✅ Edge cases: handles rapid successive requests
+
+## Test Utilities
+
+### `test-utils.ts`
+Provides reusable test utilities and helpers:
+
+- **`createTestQueryClient()`** - Creates a QueryClient optimized for testing
+- **`createWrapper()`** - Creates a wrapper component for React Query provider
+- **`makeToken(expOffset?)`** - Generates valid JWT tokens for testing
+- **`makeExpiredToken()`** - Generates expired JWT tokens
+- **`mockResponses`** - Object with helper functions for common API responses
+- **`mockErrors`** - Object with helper functions for common error scenarios
+
+## Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Run tests with coverage
+npm run test:coverage
+
+# Run specific test file
+npm test useLoginUser.test.tsx
+
+# Run tests matching a pattern
+npm test -- --testNamePattern="on success"
+```
+
+## Test Structure
+
+Each test file follows this structure:
+
+1. **Setup**
+   - Import necessary testing utilities
+   - Mock external dependencies (apiClient, authStore)
+   - Create test wrappers and helpers
+
+2. **Test Suites**
+   - `describe("on success")` - Tests for successful mutations
+   - `describe("on error")` - Tests for error handling
+   - `describe("mutation state")` - Tests for loading/pending states
+   - `describe("edge cases")` - Tests for boundary conditions
+
+3. **Cleanup**
+   - `beforeEach()` - Clears mocks before each test
+   - `afterEach()` - Cleanup if needed
+
+## Mocking Strategy
+
+### API Client Mocking
+```typescript
+jest.mock("@/lib/apiClient");
+const mockPost = jest.fn();
+(apiClient.post as jest.Mock) = mockPost;
+```
+
+### Auth Store Mocking
+```typescript
+jest.mock("@/lib/store/authStore");
+const mockLogin = jest.fn();
+(useAuthStore as unknown as jest.Mock).mockImplementation((selector) => {
+  const store = { login: mockLogin };
+  return selector(store);
+});
+```
+
+## Best Practices
+
+1. **Isolation** - Each test is independent and doesn't affect others
+2. **Clarity** - Test names clearly describe what is being tested
+3. **Completeness** - Tests cover success, error, and edge cases
+4. **Maintainability** - Shared utilities reduce code duplication
+5. **Performance** - Tests run quickly with disabled retries and garbage collection
+
+## Common Patterns
+
+### Testing Successful Mutations
+```typescript
+it("should call authStore.login with response data", async () => {
+  const token = makeToken();
+  const loginResponse = { access_token: token };
+  mockPost.mockResolvedValueOnce(loginResponse);
+
+  const { result } = renderHook(() => useLoginUser(), {
+    wrapper: createWrapper(),
+  });
+
+  await act(async () => {
+    result.current.mutate(payload);
+  });
+
+  await waitFor(() => {
+    expect(result.current.isSuccess).toBe(true);
+  });
+
+  expect(mockLogin).toHaveBeenCalledWith(loginResponse);
+});
+```
+
+### Testing Error Handling
+```typescript
+it("should set error state on failed login", async () => {
+  const error = new Error("Invalid credentials");
+  mockPost.mockRejectedValueOnce(error);
+
+  const { result } = renderHook(() => useLoginUser(), {
+    wrapper: createWrapper(),
+  });
+
+  await act(async () => {
+    result.current.mutate(payload);
+  });
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true);
+  });
+
+  expect(result.current.error).toBeDefined();
+});
+```
+
+### Testing Pending State
+```typescript
+it("should set isPending to true while mutation is in progress", async () => {
+  let resolveLogin: (value: any) => void;
+  const loginPromise = new Promise((resolve) => {
+    resolveLogin = resolve;
+  });
+
+  mockPost.mockReturnValueOnce(loginPromise);
+
+  const { result } = renderHook(() => useLoginUser(), {
+    wrapper: createWrapper(),
+  });
+
+  act(() => {
+    result.current.mutate(payload);
+  });
+
+  expect(result.current.isPending).toBe(true);
+
+  act(() => {
+    resolveLogin!({ access_token: makeToken() });
+  });
+
+  await waitFor(() => {
+    expect(result.current.isPending).toBe(false);
+  });
+});
+```
+
+## Troubleshooting
+
+### Tests Timing Out
+- Ensure `waitFor()` has appropriate timeout
+- Check that mocks are properly resolved/rejected
+- Verify `act()` is wrapping state updates
+
+### Mock Not Being Called
+- Verify mock is set up before hook is rendered
+- Check that the hook is actually calling the mocked function
+- Ensure proper cleanup between tests
+
+### Unexpected State Values
+- Use `act()` for all state updates
+- Verify `waitFor()` conditions are correct
+- Check that mocks return expected data structure
+
+## Coverage Goals
+
+- **Statements**: > 95%
+- **Branches**: > 90%
+- **Functions**: > 95%
+- **Lines**: > 95%
+
+Run `npm run test:coverage` to see current coverage metrics.

--- a/frontend/__tests__/lib/react-query/test-utils.ts
+++ b/frontend/__tests__/lib/react-query/test-utils.ts
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+/**
+ * Creates a QueryClient configured for testing with disabled retries
+ * and optimized for fast test execution
+ */
+export const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+/**
+ * Creates a wrapper component for React Query that can be used with renderHook
+ * Usage: renderHook(() => useMyHook(), { wrapper: createWrapper() })
+ */
+export const createWrapper = () => {
+  const testQueryClient = createTestQueryClient();
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: testQueryClient }, children);
+};
+
+/**
+ * Helper to create a valid JWT token for testing
+ * @param expOffset - Seconds until token expiration (default: 3600 = 1 hour)
+ * @returns A valid JWT token string
+ */
+export const makeToken = (expOffset = 3600): string => {
+  const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expOffset }));
+  return `header.${payload}.sig`;
+};
+
+/**
+ * Helper to create an expired JWT token for testing
+ * @returns An expired JWT token string
+ */
+export const makeExpiredToken = (): string => makeToken(-3600);
+
+/**
+ * Mock response builders for common API responses
+ */
+export const mockResponses = {
+  loginSuccess: (token?: string, user?: any) => ({
+    access_token: token || makeToken(),
+    user,
+  }),
+
+  registerSuccess: (token?: string, user?: any) => ({
+    access_token: token || makeToken(),
+    user,
+  }),
+
+  forgotPasswordSuccess: (message = "Password reset link sent to your email") => ({
+    message,
+  }),
+
+  errorResponse: (message: string, status: number) => {
+    const error = new Error(message);
+    (error as any).response = { status, data: { message } };
+    return error;
+  },
+};
+
+/**
+ * Mock error builders for common error scenarios
+ */
+export const mockErrors = {
+  unauthorized: () => mockResponses.errorResponse("Unauthorized", 401),
+  notFound: () => mockResponses.errorResponse("Not Found", 404),
+  badRequest: () => mockResponses.errorResponse("Bad Request", 400),
+  conflict: () => mockResponses.errorResponse("Conflict", 409),
+  tooManyRequests: () => mockResponses.errorResponse("Too Many Requests", 429),
+  serverError: () => mockResponses.errorResponse("Internal Server Error", 500),
+  networkError: () => new Error("Network Error"),
+  timeoutError: () => {
+    const error = new Error("Request timeout");
+    (error as any).code = "ECONNABORTED";
+    return error;
+  },
+};

--- a/frontend/__tests__/lib/react-query/useForgotPassword.test.tsx
+++ b/frontend/__tests__/lib/react-query/useForgotPassword.test.tsx
@@ -1,0 +1,450 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useForgotPassword } from "@/lib/react-query/hooks/auth/useForgotPassword";
+import * as apiClient from "@/lib/apiClient";
+
+// Mock the apiClient module
+jest.mock("@/lib/apiClient");
+
+// Helper to create a QueryClient for tests
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+// Wrapper component for React Query
+const createWrapper = () => {
+  const testQueryClient = createTestQueryClient();
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useForgotPassword", () => {
+  let mockPost: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock the post function
+    mockPost = jest.fn();
+    (apiClient.post as jest.Mock) = mockPost;
+  });
+
+  describe("on success", () => {
+    it("should show success message on successful forgot password request", async () => {
+      const successResponse = { message: "Password reset link sent to your email" };
+      mockPost.mockResolvedValueOnce(successResponse);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      const email = "user@example.com";
+
+      await act(async () => {
+        result.current.mutate(email);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/forgot-password", { email });
+      expect(result.current.data).toEqual(successResponse);
+      expect(result.current.data?.message).toBeDefined();
+    });
+
+    it("should set data with success message", async () => {
+      const successResponse = { message: "Check your email for reset instructions" };
+      mockPost.mockResolvedValueOnce(successResponse);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("test@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(successResponse);
+    });
+
+    it("should handle success response with additional metadata", async () => {
+      const successResponse = {
+        message: "Password reset email sent",
+        expiresIn: 3600,
+        timestamp: new Date().toISOString(),
+      };
+      mockPost.mockResolvedValueOnce(successResponse);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(successResponse);
+    });
+
+    it("should handle multiple successful requests", async () => {
+      const successResponse = { message: "Email sent" };
+      mockPost.mockResolvedValue(successResponse);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user1@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/forgot-password", { email: "user1@example.com" });
+
+      // Reset for second request
+      jest.clearAllMocks();
+      mockPost.mockResolvedValueOnce(successResponse);
+      (apiClient.post as jest.Mock) = mockPost;
+
+      await act(async () => {
+        result.current.mutate("user2@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/forgot-password", { email: "user2@example.com" });
+    });
+  });
+
+  describe("on error", () => {
+    it("should show error message on failed request", async () => {
+      const error = new Error("User not found");
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("nonexistent@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+      expect(result.current.error?.message).toBe("User not found");
+    });
+
+    it("should handle 404 not found error", async () => {
+      const error = new Error("Not Found");
+      (error as any).response = { status: 404, data: { message: "User not found" } };
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("unknown@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+
+    it("should handle 400 bad request error (invalid email)", async () => {
+      const error = new Error("Bad Request");
+      (error as any).response = { status: 400, data: { message: "Invalid email format" } };
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("invalid-email");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+
+    it("should handle 429 too many requests error", async () => {
+      const error = new Error("Too Many Requests");
+      (error as any).response = { status: 429, data: { message: "Too many reset requests. Try again later." } };
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+
+    it("should handle 500 server error", async () => {
+      const error = new Error("Internal Server Error");
+      (error as any).response = { status: 500 };
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+
+    it("should handle network error", async () => {
+      const error = new Error("Network Error");
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error?.message).toBe("Network Error");
+    });
+
+    it("should handle timeout error", async () => {
+      const error = new Error("Request timeout");
+      (error as any).code = "ECONNABORTED";
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+  });
+
+  describe("mutation state", () => {
+    it("should set isPending to true while mutation is in progress", async () => {
+      let resolveRequest: (value: any) => void;
+      const requestPromise = new Promise((resolve) => {
+        resolveRequest = resolve;
+      });
+
+      mockPost.mockReturnValueOnce(requestPromise);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.mutate("user@example.com");
+      });
+
+      expect(result.current.isPending).toBe(true);
+
+      act(() => {
+        resolveRequest!({ message: "Email sent" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(false);
+      });
+    });
+
+    it("should use correct mutation key", () => {
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.mutationKey).toEqual(["auth", "forgot-password"]);
+    });
+
+    it("should reset error state on new mutation", async () => {
+      const error = new Error("User not found");
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      // First request fails
+      await act(async () => {
+        result.current.mutate("nonexistent@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+
+      // Second request succeeds
+      mockPost.mockResolvedValueOnce({ message: "Email sent" });
+
+      await act(async () => {
+        result.current.mutate("valid@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle email with special characters", async () => {
+      const successResponse = { message: "Email sent" };
+      mockPost.mockResolvedValueOnce(successResponse);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      const specialEmail = "user+tag@example.co.uk";
+
+      await act(async () => {
+        result.current.mutate(specialEmail);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/forgot-password", { email: specialEmail });
+    });
+
+    it("should handle email with subdomain", async () => {
+      const successResponse = { message: "Email sent" };
+      mockPost.mockResolvedValueOnce(successResponse);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      const subdomainEmail = "user@mail.example.com";
+
+      await act(async () => {
+        result.current.mutate(subdomainEmail);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/forgot-password", { email: subdomainEmail });
+    });
+
+    it("should handle rapid successive requests", async () => {
+      const successResponse = { message: "Email sent" };
+      mockPost.mockResolvedValue(successResponse);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user1@example.com");
+        result.current.mutate("user2@example.com");
+        result.current.mutate("user3@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledTimes(3);
+    });
+
+    it("should handle empty response gracefully", async () => {
+      mockPost.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual({});
+    });
+
+    it("should handle response with null message", async () => {
+      const successResponse = { message: null };
+      mockPost.mockResolvedValueOnce(successResponse);
+
+      const { result } = renderHook(() => useForgotPassword(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate("user@example.com");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(successResponse);
+    });
+  });
+});

--- a/frontend/__tests__/lib/react-query/useLoginUser.test.tsx
+++ b/frontend/__tests__/lib/react-query/useLoginUser.test.tsx
@@ -1,0 +1,293 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useLoginUser } from "@/lib/react-query/hooks/auth/useLoginUser";
+import { useAuthStore } from "@/lib/store/authStore";
+import * as apiClient from "@/lib/apiClient";
+import type { User } from "@/types/user";
+
+// Mock the apiClient module
+jest.mock("@/lib/apiClient");
+
+// Mock the authStore
+jest.mock("@/lib/store/authStore");
+
+// Helper to create valid JWT token
+const makeToken = (expOffset = 3600) => {
+  const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expOffset }));
+  return `header.${payload}.sig`;
+};
+
+// Helper to create a QueryClient for tests
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+// Wrapper component for React Query
+const createWrapper = () => {
+  const testQueryClient = createTestQueryClient();
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useLoginUser", () => {
+  let mockPost: jest.Mock;
+  let mockLogin: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock the post function
+    mockPost = jest.fn();
+    (apiClient.post as jest.Mock) = mockPost;
+
+    // Mock the authStore login method
+    mockLogin = jest.fn();
+    (useAuthStore as unknown as jest.Mock).mockImplementation((selector) => {
+      const store = { login: mockLogin };
+      return selector(store);
+    });
+  });
+
+  describe("on success", () => {
+    it("should call authStore.login with response data", async () => {
+      const token = makeToken();
+      const user: User = {
+        id: "1",
+        firstname: "John",
+        lastname: "Doe",
+        email: "john@example.com",
+        role: "member",
+        verified: true,
+        active: true,
+        joinedDate: "2024-01-01",
+        name: "John Doe",
+        createdAt: "2024-01-01",
+        updatedAt: "2024-01-01",
+      };
+
+      const loginResponse = { access_token: token, user };
+      mockPost.mockResolvedValueOnce(loginResponse);
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      const payload = { email: "john@example.com", password: "password123" };
+
+      await act(async () => {
+        result.current.mutate(payload);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/login", payload);
+      expect(mockLogin).toHaveBeenCalledWith(loginResponse);
+    });
+
+    it("should set data on successful login", async () => {
+      const token = makeToken();
+      const loginResponse = { access_token: token };
+      mockPost.mockResolvedValueOnce(loginResponse);
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ email: "test@example.com", password: "pass" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(loginResponse);
+    });
+
+    it("should handle login without user data", async () => {
+      const token = makeToken();
+      const loginResponse = { access_token: token };
+      mockPost.mockResolvedValueOnce(loginResponse);
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ email: "test@example.com", password: "pass" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockLogin).toHaveBeenCalledWith(loginResponse);
+    });
+  });
+
+  describe("on error", () => {
+    it("should set error state on failed login", async () => {
+      const error = new Error("Invalid credentials");
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ email: "test@example.com", password: "wrong" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    it("should not call authStore.login on error", async () => {
+      const error = new Error("Network error");
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ email: "test@example.com", password: "pass" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    it("should handle 401 unauthorized error", async () => {
+      const error = new Error("Unauthorized");
+      (error as any).response = { status: 401 };
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ email: "test@example.com", password: "wrong" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+
+    it("should handle server error (500)", async () => {
+      const error = new Error("Internal Server Error");
+      (error as any).response = { status: 500 };
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ email: "test@example.com", password: "pass" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+  });
+
+  describe("mutation state", () => {
+    it("should set isPending to true while mutation is in progress", async () => {
+      let resolveLogin: (value: any) => void;
+      const loginPromise = new Promise((resolve) => {
+        resolveLogin = resolve;
+      });
+
+      mockPost.mockReturnValueOnce(loginPromise);
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.mutate({ email: "test@example.com", password: "pass" });
+      });
+
+      expect(result.current.isPending).toBe(true);
+
+      act(() => {
+        resolveLogin!({ access_token: makeToken() });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(false);
+      });
+    });
+
+    it("should use correct mutation key", () => {
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.mutationKey).toEqual(["auth", "login"]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle rapid successive mutations", async () => {
+      const token = makeToken();
+      mockPost.mockResolvedValue({ access_token: token });
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ email: "test1@example.com", password: "pass1" });
+        result.current.mutate({ email: "test2@example.com", password: "pass2" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      // Should have been called twice
+      expect(mockPost).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle empty response gracefully", async () => {
+      mockPost.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useLoginUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ email: "test@example.com", password: "pass" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockLogin).toHaveBeenCalledWith({});
+    });
+  });
+});

--- a/frontend/__tests__/lib/react-query/useRegisterUser.test.tsx
+++ b/frontend/__tests__/lib/react-query/useRegisterUser.test.tsx
@@ -1,0 +1,482 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useRegisterUser } from "@/lib/react-query/hooks/auth/useRegisterUser";
+import { useAuthStore } from "@/lib/store/authStore";
+import * as apiClient from "@/lib/apiClient";
+import type { User } from "@/types/user";
+
+// Mock the apiClient module
+jest.mock("@/lib/apiClient");
+
+// Mock the authStore
+jest.mock("@/lib/store/authStore");
+
+// Mock next/router for navigation
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+// Mock next/navigation for app router
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+// Helper to create valid JWT token
+const makeToken = (expOffset = 3600) => {
+  const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expOffset }));
+  return `header.${payload}.sig`;
+};
+
+// Helper to create a QueryClient for tests
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+// Wrapper component for React Query
+const createWrapper = () => {
+  const testQueryClient = createTestQueryClient();
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useRegisterUser", () => {
+  let mockPost: jest.Mock;
+  let mockRegister: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock the post function
+    mockPost = jest.fn();
+    (apiClient.post as jest.Mock) = mockPost;
+
+    // Mock the authStore register method
+    mockRegister = jest.fn();
+    (useAuthStore as unknown as jest.Mock).mockImplementation((selector) => {
+      const store = { register: mockRegister };
+      return selector(store);
+    });
+  });
+
+  describe("on success", () => {
+    it("should call authStore.register with response data when access_token is present", async () => {
+      const token = makeToken();
+      const user: User = {
+        id: "1",
+        firstname: "Jane",
+        lastname: "Smith",
+        email: "jane@example.com",
+        role: "member",
+        verified: false,
+        active: true,
+        joinedDate: "2024-01-01",
+        name: "Jane Smith",
+        createdAt: "2024-01-01",
+        updatedAt: "2024-01-01",
+      };
+
+      const registerResponse = { access_token: token, user };
+      mockPost.mockResolvedValueOnce(registerResponse);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      const payload = {
+        firstname: "Jane",
+        lastname: "Smith",
+        email: "jane@example.com",
+        password: "SecurePass123!",
+      };
+
+      await act(async () => {
+        result.current.mutate(payload);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/register", payload);
+      expect(mockRegister).toHaveBeenCalledWith({
+        access_token: token,
+        user,
+      });
+    });
+
+    it("should not call authStore.register when access_token is missing", async () => {
+      const registerResponse = { message: "Registration successful, please verify email" };
+      mockPost.mockResolvedValueOnce(registerResponse);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      const payload = {
+        firstname: "John",
+        lastname: "Doe",
+        email: "john@example.com",
+        password: "SecurePass123!",
+      };
+
+      await act(async () => {
+        result.current.mutate(payload);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+
+    it("should set data on successful registration", async () => {
+      const token = makeToken();
+      const registerResponse = { access_token: token };
+      mockPost.mockResolvedValueOnce(registerResponse);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      const payload = {
+        firstname: "Test",
+        lastname: "User",
+        email: "test@example.com",
+        password: "pass123",
+      };
+
+      await act(async () => {
+        result.current.mutate(payload);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(registerResponse);
+    });
+
+    it("should handle registration with user data but no token", async () => {
+      const user: User = {
+        id: "1",
+        firstname: "Jane",
+        lastname: "Smith",
+        email: "jane@example.com",
+        role: "member",
+        verified: false,
+        active: true,
+        joinedDate: "2024-01-01",
+        name: "Jane Smith",
+        createdAt: "2024-01-01",
+        updatedAt: "2024-01-01",
+      };
+
+      const registerResponse = { user, message: "Please verify your email" };
+      mockPost.mockResolvedValueOnce(registerResponse);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          firstname: "Jane",
+          lastname: "Smith",
+          email: "jane@example.com",
+          password: "pass",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("on error", () => {
+    it("should set error state on failed registration", async () => {
+      const error = new Error("Email already exists");
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          firstname: "Jane",
+          lastname: "Smith",
+          email: "existing@example.com",
+          password: "pass",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+
+    it("should display error message on validation failure", async () => {
+      const error = new Error("Password too weak");
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          firstname: "Jane",
+          lastname: "Smith",
+          email: "jane@example.com",
+          password: "weak",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error?.message).toBe("Password too weak");
+    });
+
+    it("should handle 409 conflict error (email exists)", async () => {
+      const error = new Error("Conflict");
+      (error as any).response = { status: 409, data: { message: "Email already registered" } };
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          firstname: "Jane",
+          lastname: "Smith",
+          email: "taken@example.com",
+          password: "pass",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+
+    it("should handle 400 bad request error", async () => {
+      const error = new Error("Bad Request");
+      (error as any).response = { status: 400, data: { message: "Invalid input" } };
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          firstname: "",
+          lastname: "Smith",
+          email: "invalid-email",
+          password: "pass",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    });
+
+    it("should handle network error", async () => {
+      const error = new Error("Network Error");
+      mockPost.mockRejectedValueOnce(error);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          firstname: "Jane",
+          lastname: "Smith",
+          email: "jane@example.com",
+          password: "pass",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mutation state", () => {
+    it("should set isPending to true while mutation is in progress", async () => {
+      let resolveRegister: (value: any) => void;
+      const registerPromise = new Promise((resolve) => {
+        resolveRegister = resolve;
+      });
+
+      mockPost.mockReturnValueOnce(registerPromise);
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.mutate({
+          firstname: "Jane",
+          lastname: "Smith",
+          email: "jane@example.com",
+          password: "pass",
+        });
+      });
+
+      expect(result.current.isPending).toBe(true);
+
+      act(() => {
+        resolveRegister!({ access_token: makeToken() });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(false);
+      });
+    });
+
+    it("should use correct mutation key", () => {
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.mutationKey).toEqual(["auth", "register"]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle registration with special characters in name", async () => {
+      const token = makeToken();
+      mockPost.mockResolvedValueOnce({ access_token: token });
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      const payload = {
+        firstname: "José",
+        lastname: "García-López",
+        email: "jose@example.com",
+        password: "pass",
+      };
+
+      await act(async () => {
+        result.current.mutate(payload);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/register", payload);
+    });
+
+    it("should handle registration with long email", async () => {
+      const token = makeToken();
+      mockPost.mockResolvedValueOnce({ access_token: token });
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      const longEmail = "very.long.email.address.with.many.parts@subdomain.example.com";
+      const payload = {
+        firstname: "Test",
+        lastname: "User",
+        email: longEmail,
+        password: "pass",
+      };
+
+      await act(async () => {
+        result.current.mutate(payload);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/auth/register", payload);
+    });
+
+    it("should handle rapid successive registrations", async () => {
+      const token = makeToken();
+      mockPost.mockResolvedValue({ access_token: token });
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          firstname: "User1",
+          lastname: "Test",
+          email: "user1@example.com",
+          password: "pass",
+        });
+        result.current.mutate({
+          firstname: "User2",
+          lastname: "Test",
+          email: "user2@example.com",
+          password: "pass",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPost).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle empty response gracefully", async () => {
+      mockPost.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useRegisterUser(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          firstname: "Test",
+          lastname: "User",
+          email: "test@example.com",
+          password: "pass",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
closes #155

Description
Add integration tests for React Query mutation hooks:

useLoginUser: on success, authStore.login is called with response data; on error, error state is set.
useRegisterUser: on success, redirects to verify-otp page; on error, error message is displayed.
useForgotPassword: on success, shows success message; on error, shows error.
Use @testing-library/react with a QueryClientProvider wrapper.
Mock apiClient using jest.mock.
Place tests in frontend/__tests__/lib/react-query/.