### PR TITLE
fix: resolve bugs #185, #189, #190, #191

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -46,8 +46,8 @@ export class AuthController {
       },
     },
   })
-  register(@Body() body: { email: string; password: string }) {
-    return this.authService.register(body.email, body.password);
+  register(@Body() body: { firstName: string; lastName: string; email: string; password: string }) {
+    return this.authService.register(body.email, body.password, body.firstName, body.lastName);
   }
 
   @Post('login')

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -45,7 +45,7 @@ export class AuthService {
     return regex.test(password);
   }
 
-  async register(email: string, password: string) {
+  async register(email: string, password: string, firstName?: string, lastName?: string) {
     const passwordHash = await bcrypt.hash(password, 10);
     const otp = this.generateOtp();
     const otpHash = await this.hashOtp(otp);
@@ -56,6 +56,8 @@ export class AuthService {
       passwordHash,
       otp: otpHash,
       otpExpiry,
+      firstName,
+      lastName,
     });
 
     // Send OTP email (non-blocking)

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -11,6 +11,12 @@ export class User {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
+  @Column({ nullable: true })
+  firstName?: string;
+
+  @Column({ nullable: true })
+  lastName?: string;
+
   @Column({ unique: true })
   email!: string;
 

--- a/backend/src/workspaces/workspaces.service.ts
+++ b/backend/src/workspaces/workspaces.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { Workspace, WorkspaceType, WorkspaceAvailability } from './workspace.entity';
 import { CreateWorkspaceDto, UpdateWorkspaceDto } from './workspaces.dto';
 
@@ -38,7 +38,7 @@ export class WorkspacesService {
 
   async findById(id: string) {
     const workspace = await this.repo.findOne({
-      where: { id, deletedAt: null as any },
+      where: { id, deletedAt: IsNull() },
     });
     if (!workspace) {
       throw new NotFoundException('Workspace not found');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -41,7 +41,7 @@ export const api = {
       body: JSON.stringify({ email, password }),
     }),
 
-  register: (data: { firstname: string; lastname: string; email: string; password: string }) =>
+  register: (data: { firstName: string; lastName: string; email: string; password: string }) =>
     request<{ message: string }>('/auth/register', {
       method: 'POST',
       body: JSON.stringify(data),


### PR DESCRIPTION
## Summary

Fixes four reported bugs across the backend and frontend.
closes #191 
### — WorkspacesService.findById: use IsNull() instead of null
TypeORM soft-delete requires `IsNull()` in the where clause. Passing plain `null` generates invalid SQL. Added `IsNull` import and replaced `deletedAt: null as any` with `deletedAt: IsNull()`.

closes #190 
### — Register flow: support firstName/lastName end-to-end
- Added `firstName` and `lastName` nullable columns to `user.entity.ts`
- Updated `auth.controller.ts` register endpoint to accept and forward them
- Updated `auth.service.ts` register() signature to store them via `usersService.create()`
- Aligned `frontend/src/lib/api.ts` register type to camelCase (`firstName`/`lastName`)
closes #189 
### — AuthService.verifyOtp() recursive call
Verified the private helper is already named `verifyOtpHash` and the public `verifyOtp` correctly calls `this.verifyOtpHash()`. No recursive call exists in the current codebase.
closes #185
###  — UsersService duplicate update() method
Verified `UsersService` has a single `update()` method delegating to `UpdateUserProvider`. No duplicate exists in the current codebase.

## Files Changed
- `backend/src/workspaces/workspaces.service.ts`
- `backend/src/users/user.entity.ts`
- `backend/src/auth/auth.controller.ts`
- `backend/src/auth/auth.service.ts`
- `frontend/src/lib/api.ts`

Closes #185, #189, #190, #191