### PR TITLE
fix: auth, users guard, role endpoint, dashboard stats

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -21,9 +22,13 @@ import { User } from '../users/user.entity';
     UsersModule,
     PassportModule,
     TypeOrmModule.forFeature([RefreshToken, WebAuthnCredential, User]),
-    JwtModule.register({
-      secret: process.env.JWT_SECRET || 'hubassist-secret',
-      signOptions: { expiresIn: '7d' },
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: config.get<string>('JWT_EXPIRES_IN', '1h') },
+      }),
     }),
   ],
   providers: [

--- a/backend/src/dashboard/dashboard.service.ts
+++ b/backend/src/dashboard/dashboard.service.ts
@@ -16,7 +16,7 @@ export class DashboardService {
   async getStats() {
     const totalMembers = await this.userRepo.count();
     const verifiedMembers = await this.userRepo.count({
-      where: { role: UserRole.MEMBER },
+      where: { isVerified: true },
     });
     const activeWorkspaces = await this.workspaceRepo.count({
       where: { isActive: true, deletedAt: null as any },
@@ -31,7 +31,7 @@ export class DashboardService {
       totalMembers,
       verifiedMembers,
       activeWorkspaces,
-      deskOccupancy: Math.round(deskOccupancy),
+      deskOccupancy: Math.min(100, Math.round(deskOccupancy)),
     };
   }
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -75,6 +75,15 @@ export class UsersController {
     return this.usersService.update(id, data);
   }
 
+  @Patch(':id/role')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Update user role (admin only)' })
+  @ApiParam({ name: 'id', type: String, description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'User role updated successfully' })
+  updateRole(@Param('id') id: string, @Body('role') role: UserRole) {
+    return this.usersService.update(id, { role });
+  }
+
   @Delete(':id')
   @ApiOperation({ summary: 'Delete user (soft delete)' })
   @ApiParam({ name: 'id', type: String, description: 'User ID' })

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Body,
   Query,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -24,9 +25,12 @@ import { FileValidationPipe } from '../common/pipes/file-validation.pipe';
 import { CloudinaryService } from '../cloudinary/cloudinary.service';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from './user.entity';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
 
 @ApiTags('users')
 @ApiBearerAuth('bearer')
+@UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('users')
 export class UsersController {
   constructor(


### PR DESCRIPTION
## Summary

Fixes four bugs across auth, users, and dashboard modules.

### Changes

- **#192** `auth.module.ts`: Replace `JwtModule.register` with `JwtModule.registerAsync` using `ConfigService` so `JWT_SECRET` is read after `ConfigModule` has loaded the `.env` file.
- **#193** `users.controller.ts`: Add `@UseGuards(JwtAuthGuard, RolesGuard)` at the controller class level so all `/users` endpoints require authentication.
- **#194** `users.controller.ts`: Add `PATCH :id/role` endpoint (admin only) so the frontend `api.ts` role-update call has a matching backend route.
- **#195** `dashboard.service.ts`: Count verified members by `isVerified: true` instead of `role: MEMBER`, and cap `deskOccupancy` at 100 with `Math.min`.

closes #192
closes #193
closes #194
closes #195