### PR TITLE
fix: resolve backend entity and module bugs (#184, #183, #182)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,8 +8,11 @@ import { UsersModule } from './users/users.module';
 import { ContactModule } from './contact/contact.module';
 import { AttendanceModule } from './attendance/attendance.module';
 import { BookingsModule } from './bookings/bookings.module';
+import { WorkspacesModule } from './workspaces/workspaces.module';
 import { StellarModule } from './stellar/stellar.module';
 import { DashboardModule } from './dashboard/dashboard.module';
+import { NewsletterModule } from './newsletter/newsletter.module';
+import { CloudinaryModule } from './cloudinary/cloudinary.module';
 import appConfig from './config/app.config';
 import databaseConfig from './config/database.config';
 import { validationSchema } from './config/validation.schema';
@@ -37,8 +40,11 @@ import { RolesGuard } from './common/guards/roles.guard';
     ContactModule,
     AttendanceModule,
     BookingsModule,
+    WorkspacesModule,
     StellarModule,
     DashboardModule,
+    NewsletterModule,
+    CloudinaryModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/bookings/booking.entity.ts
+++ b/backend/src/bookings/booking.entity.ts
@@ -5,7 +5,6 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   ManyToOne,
-  ForeignKey,
   JoinColumn,
 } from 'typeorm';
 import { Workspace } from '../workspaces/workspace.entity';
@@ -24,7 +23,6 @@ export class Booking {
   id!: string;
 
   @Column()
-  @ForeignKey(() => Workspace)
   workspaceId!: string;
 
   @ManyToOne(() => Workspace)
@@ -32,7 +30,6 @@ export class Booking {
   workspace!: Workspace;
 
   @Column()
-  @ForeignKey(() => User)
   userId!: string;
 
   @ManyToOne(() => User)

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -17,6 +17,12 @@ export class User {
   @Column()
   passwordHash!: string;
 
+  @Column({ nullable: true })
+  firstName?: string;
+
+  @Column({ nullable: true })
+  lastName?: string;
+
   @Column({ type: 'enum', enum: UserRole, default: UserRole.MEMBER })
   role!: UserRole;
 
@@ -32,6 +38,9 @@ export class User {
 
    @Column({ default: false })
    isVerified: boolean;
+
+   @Column({ default: true })
+   isActive: boolean;
 
    @Column({ nullable: true })
    profilePicture?: string;


### PR DESCRIPTION
## Summary

This PR fixes three backend bugs affecting TypeORM entity definitions and NestJS module registration.

---

### #184 — Remove non-existent `@ForeignKey` decorator from `booking.entity.ts`

**File:** `backend/src/bookings/booking.entity.ts`

TypeORM does not export a `@ForeignKey` decorator. The import and both usages on `workspaceId` and `userId` caused a compile-time error. The correct approach — `@ManyToOne` + `@JoinColumn` — was already in place, so the `@ForeignKey` lines were simply removed.

---

### #183 — Register missing modules in `AppModule`

**File:** `backend/src/app.module.ts`

`WorkspacesModule`, `NewsletterModule`, and `CloudinaryModule` were never imported into `AppModule`, causing all `/api/workspaces` and `/api/newsletter` routes to return 404. All three modules have been added to the `imports` array along with their import statements.

---

### #182 — Add missing columns to `user.entity.ts`

**File:** `backend/src/users/user.entity.ts`

The following columns were missing from the User entity, causing runtime failures in auth and user flows:

| Column | Type | Notes |
|---|---|---|
| `firstName` | `string` (nullable) | Used in frontend register call |
| `lastName` | `string` (nullable) | Used in frontend register call |
| `isActive` | `boolean` (default: true) | Used in activate/deactivate endpoints |

Fields already present: `otp`, `otpExpiry`, `isVerified`, `profilePicture`, `DeleteDateColumn`.

---

## Testing

- TypeScript compilation no longer errors on `@ForeignKey`
- All workspace, newsletter, and cloudinary routes are now registered
- TypeORM will generate the correct schema columns for the User table

Closes #184
Closes #183
Closes #182