### PR TITLE
Fix: Add .env.example and ensure NEXT_PUBLIC_API_URL fallback in env.ts

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Environment variables for Hub-Assist frontend
+NEXT_PUBLIC_API_URL=http://localhost:3001/api


### PR DESCRIPTION
closes #205 
## Pull Request Description

### Problem
The frontend's `NEXT_PUBLIC_API_URL` environment variable was not set, causing all API calls to fail with an invalid base URL. The env.ts file reads this variable, and while there was a fallback in place, the lack of proper environment configuration led to issues.

### Solution
- Created .env.local (gitignored) with `NEXT_PUBLIC_API_URL=http://localhost:3001/api` to set the API URL for local development.
- Added .env.example to document the required environment variable for other developers.
- Verified that env.ts includes a hard fallback: `apiUrl: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api'`.

### Changes Made
- **.env.local**: New file with API URL configuration.
- **.env.example**: New file documenting the environment variable.

### Testing
No tests were executed as specified in the issue requirements. The changes ensure the API URL is properly configured with a fallback.

### Related Issue
Fixes the bug where API calls were going to the wrong URL due to missing environment configuration.