### PR TITLE
 Dashboard growth endpoint + auth e2e test coverage

### DIFF
--- a/backend/src/dashboard/dashboard.controller.ts
+++ b/backend/src/dashboard/dashboard.controller.ts
@@ -24,6 +24,13 @@ export class DashboardController {
     return this.service.getActivity();
   }
 
+  @Get('growth')
+  @ApiOperation({ summary: 'Get member growth over the last 12 months' })
+  @ApiResponse({ status: 200, description: 'Member growth data retrieved successfully' })
+  getGrowth() {
+    return this.service.getGrowth();
+  }
+
   @Get('admin-stats')
   @Roles(UserRole.ADMIN)
   @ApiOperation({ summary: 'Get admin statistics (admin only)' })

--- a/backend/src/dashboard/dashboard.service.ts
+++ b/backend/src/dashboard/dashboard.service.ts
@@ -49,6 +49,22 @@ export class DashboardService {
     }));
   }
 
+  async getGrowth(): Promise<Array<{ date: string; members: number }>> {
+    const results = await this.userRepo
+      .createQueryBuilder('user')
+      .select("TO_CHAR(DATE_TRUNC('month', user.createdAt), 'YYYY-MM')", 'date')
+      .addSelect('COUNT(user.id)', 'members')
+      .where("user.createdAt >= NOW() - INTERVAL '12 months'")
+      .groupBy("DATE_TRUNC('month', user.createdAt)")
+      .orderBy("DATE_TRUNC('month', user.createdAt)", 'ASC')
+      .getRawMany();
+
+    return results.map((r) => ({
+      date: r.date,
+      members: parseInt(r.members, 10),
+    }));
+  }
+
   async getAdminStats() {
     const stats = await this.getStats();
     const totalBookings = await this.bookingRepo.count();

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -59,7 +59,9 @@ describe('Auth (e2e)', () => {
 
   describe('POST /api/auth/register', () => {
     it('201 – creates user and returns message', async () => {
-      mockAuthService.register.mockResolvedValue({ message: 'User registered. Check your email for OTP.' });
+      mockAuthService.register.mockResolvedValue({
+        message: 'User registered. Check your email for OTP.',
+      });
 
       return request(app.getHttpServer())
         .post('/api/auth/register')
@@ -132,11 +134,54 @@ describe('Auth (e2e)', () => {
     });
 
     it('401 – invalid refresh token returns unauthorized', async () => {
-      mockAuthService.refresh.mockRejectedValue(new UnauthorizedException('Invalid or revoked refresh token'));
+      mockAuthService.refresh.mockRejectedValue(
+        new UnauthorizedException('Invalid or revoked refresh token'),
+      );
 
       return request(app.getHttpServer())
         .post('/api/auth/refresh')
         .send({ refreshToken: 'invalid-token' })
+        .expect(401);
+    });
+  });
+
+  // ── POST /api/auth/forgot-password ────────────────────────────────────────
+
+  describe('POST /api/auth/forgot-password', () => {
+    it('201 – sends reset OTP for existing email', async () => {
+      mockAuthService.forgotPassword.mockResolvedValue({
+        message: 'Password reset OTP sent to your email',
+      });
+
+      return request(app.getHttpServer())
+        .post('/api/auth/forgot-password')
+        .send({ email: 'user@test.com' })
+        .expect(201)
+        .expect((res) => expect(res.body.message).toBeDefined());
+    });
+  });
+
+  // ── POST /api/auth/reset-password ─────────────────────────────────────────
+
+  describe('POST /api/auth/reset-password', () => {
+    it('201 – resets password with valid OTP', async () => {
+      mockAuthService.resetPassword.mockResolvedValue({ message: 'Password reset successfully' });
+
+      return request(app.getHttpServer())
+        .post('/api/auth/reset-password')
+        .send({ email: 'user@test.com', otp: '123456', newPassword: 'NewSecurePass123' })
+        .expect(201)
+        .expect((res) => expect(res.body.message).toBe('Password reset successfully'));
+    });
+
+    it('401 – invalid OTP returns unauthorized', async () => {
+      mockAuthService.resetPassword.mockRejectedValue(
+        new UnauthorizedException('Invalid or expired OTP'),
+      );
+
+      return request(app.getHttpServer())
+        .post('/api/auth/reset-password')
+        .send({ email: 'user@test.com', otp: '000000', newPassword: 'NewSecurePass123' })
         .expect(401);
     });
   });


### PR DESCRIPTION

### 1. `GET /dashboard/growth` endpoint (404 fix)

**backend/src/dashboard/dashboard.service.ts**
Added `getGrowth()` — queries the `user` table, groups registrations by month over the last 12 months, returns `Array<{ date: string; members: number }>`.

**backend/src/dashboard/dashboard.controller.ts**
Exposed `GET /dashboard/growth` wired to `getGrowth()`.

Resolves the 404 hit by `getDashboardGrowth()` in `frontend/src/lib/apiClient.ts`.

---

### 2. Auth e2e test coverage (`backend/test/auth.e2e-spec.ts`)

Added test suites for the two previously uncovered endpoints:

**`POST /api/auth/forgot-password`**

- 201 — sends reset OTP for a valid email

**`POST /api/auth/reset-password`**

- 201 — resets password with a valid OTP
- 401 — rejects an invalid/expired OTP



closes #211
closes #212

