### PR TITLE
fix: resolve auth flow, booking totalAmount, dashboard data, and middleware token key

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -93,7 +93,16 @@ export class AuthService {
       otpExpiry: undefined,
     });
 
-    return { message: 'Email verified successfully' };
+    const refreshToken = this.generateRefreshToken();
+    const refreshTokenHash = await this.hashRefreshToken(refreshToken);
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    await this.refreshTokenRepository.create(user.id, refreshTokenHash, expiresAt);
+
+    return {
+      access_token: this.jwtService.sign({ sub: user.id, email: user.email, role: user.role }),
+      refresh_token: refreshToken,
+    };
   }
 
   async resendOtp(email: string) {

--- a/backend/src/bookings/bookings.dto.ts
+++ b/backend/src/bookings/bookings.dto.ts
@@ -13,8 +13,9 @@ export class CreateBookingDto {
   @IsDateString()
   endTime!: string;
 
+  @IsOptional()
   @IsNumber()
-  totalAmount!: number;
+  totalAmount?: number;
 
   @IsOptional()
   @SanitizeString()

--- a/backend/src/bookings/bookings.service.ts
+++ b/backend/src/bookings/bookings.service.ts
@@ -36,11 +36,15 @@ export class BookingsService {
       throw new ConflictException('Workspace has overlapping bookings');
     }
 
+    const hours = (endTime.getTime() - startTime.getTime()) / (1000 * 60 * 60);
+    const totalAmount = Number((hours * Number(workspace.pricePerHour)).toFixed(2));
+
     const booking = this.repo.create({
       ...dto,
       userId,
       startTime,
       endTime,
+      totalAmount,
       status: BookingStatus.PENDING,
     });
 

--- a/backend/src/dashboard/dashboard.service.ts
+++ b/backend/src/dashboard/dashboard.service.ts
@@ -43,7 +43,8 @@ export class DashboardService {
     });
 
     return recentBookings.map((booking) => ({
-      type: 'booking',
+      id: booking.id,
+      icon: '📅',
       description: `${booking.user.email} booked ${booking.workspace.name}`,
       timestamp: booking.createdAt,
     }));

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -40,18 +40,23 @@ export function middleware(request: NextRequest) {
       return NextResponse.redirect(loginUrl);
     }
 
-    const requiredRole = protectedRoutes[matchedRoute];
-    if (requiredRole) {
-      try {
-        const payload = JSON.parse(atob(token.split(".")[1]));
-        if (payload.role !== requiredRole) {
-          return NextResponse.redirect(new URL("/dashboard", request.url));
-        }
-      } catch {
+    // Check token expiry
+    try {
+      const payload = JSON.parse(atob(token.split(".")[1]));
+      if (Date.now() >= payload.exp * 1000) {
         const loginUrl = new URL("/login", request.url);
         loginUrl.searchParams.set("redirect", pathname);
         return NextResponse.redirect(loginUrl);
       }
+
+      const requiredRole = protectedRoutes[matchedRoute];
+      if (requiredRole && payload.role !== requiredRole) {
+        return NextResponse.redirect(new URL("/dashboard", request.url));
+      }
+    } catch {
+      const loginUrl = new URL("/login", request.url);
+      loginUrl.searchParams.set("redirect", pathname);
+      return NextResponse.redirect(loginUrl);
     }
   }
 

--- a/frontend/src/app/(auth)/verify-otp/page.tsx
+++ b/frontend/src/app/(auth)/verify-otp/page.tsx
@@ -59,7 +59,8 @@ function VerifyOtpContent() {
     setError(null);
     setIsPending(true);
     try {
-      await post('/auth/verify-otp', { email, otp });
+      const data = await post<{ access_token: string }>('/auth/verify-otp', { email, otp });
+      document.cookie = `token=${data.access_token}; path=/; SameSite=Lax`;
       router.push("/dashboard");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Invalid or expired OTP.");

--- a/frontend/src/components/dashboard/AdminOverview.tsx
+++ b/frontend/src/components/dashboard/AdminOverview.tsx
@@ -5,13 +5,13 @@ import { get } from "@/lib/apiClient";
 
 export function AdminOverview() {
   const { data, isPending } = useQuery({
-    queryKey: ["dashboard-stats"],
-    queryFn: () => get<{ pendingBookings?: number; revenueThisMonth?: number }>("/dashboard/stats"),
+    queryKey: ["dashboard-admin-stats"],
+    queryFn: () => get<{ totalBookings?: number; revenue?: number }>("/dashboard/admin-stats"),
   });
 
   const stats = [
-    { label: "PENDING BOOKINGS", value: isPending ? "—" : (data?.pendingBookings ?? 0) },
-    { label: "REVENUE THIS MONTH", value: isPending ? "—" : `$${data?.revenueThisMonth ?? 0}` },
+    { label: "TOTAL BOOKINGS", value: isPending ? "—" : (data?.totalBookings ?? 0) },
+    { label: "TOTAL REVENUE", value: isPending ? "—" : `$${data?.revenue ?? 0}` },
   ];
 
   return (

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -129,7 +129,7 @@ export const api = {
     post<{ message: string }>('/auth/reset-password', { email, otp, newPassword }),
 
   verifyOtp: (email: string, otp: string) =>
-    post<{ access_token: string }>('/auth/verify-otp', { email, otp }),
+    post<{ access_token: string; refresh_token: string }>('/auth/verify-otp', { email, otp }),
 
   resendOtp: (email: string) =>
     post<{ message: string }>('/auth/resend-otp', { email }),

--- a/frontend/src/lib/store/authStore.ts
+++ b/frontend/src/lib/store/authStore.ts
@@ -72,29 +72,46 @@ export const useAuthStore = create<AuthStore>()(
         initializeAuth: () => {
           const { accessToken } = get();
           if (accessToken && !isTokenExpired(accessToken)) {
+            if (typeof document !== 'undefined') {
+              document.cookie = `token=${accessToken}; path=/; SameSite=Lax`;
+            }
             set({ isAuthenticated: true });
           } else {
+            if (typeof document !== 'undefined') {
+              document.cookie = 'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+            }
             get().clearAuth();
           }
         },
 
-        login: ({ access_token, user }) =>
+        login: ({ access_token, user }) => {
+          if (typeof document !== 'undefined') {
+            document.cookie = `token=${access_token}; path=/; SameSite=Lax`;
+          }
           set({
             accessToken: access_token,
             token: access_token,
             isAuthenticated: true,
             ...(user ? { user } : {}),
-          }),
+          });
+        },
 
-        register: ({ access_token, user }) =>
+        register: ({ access_token, user }) => {
+          if (typeof document !== 'undefined') {
+            document.cookie = `token=${access_token}; path=/; SameSite=Lax`;
+          }
           set({
             accessToken: access_token,
             token: access_token,
             isAuthenticated: true,
             ...(user ? { user } : {}),
-          }),
+          });
+        },
 
         logout: () => {
+          if (typeof document !== 'undefined') {
+            document.cookie = 'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+          }
           get().clearAuth();
           if (typeof window !== 'undefined') window.location.href = '/login';
         },


### PR DESCRIPTION
## Summary

Fixes four bugs across the frontend and backend.

---

### #206 — Fix middleware token key mismatch

**Problem:** `middleware.ts` reads `cookies.get('token')` to protect routes, but `authStore.ts` only persists state to `localStorage` via Zustand `persist`. No cookie was ever written, so authenticated users were always redirected to `/login`.

**Fix:**
- `authStore.ts`: write a `token` cookie on `login()`, `register()`, and `initializeAuth()`; clear it on `logout()` and when the stored token is expired.
- `middleware.ts`: consolidate role and expiry checks into a single `try/catch`; redirect to login when the JWT is expired.

---

### #207 — Calculate booking `totalAmount` server-side

**Problem:** `booking.entity.ts` has `totalAmount` as a non-nullable column. `CreateBookingDto` required it, but `api.createBooking` never sent it — causing a `NOT NULL` constraint violation on every booking creation.

**Fix:**
- `bookings.service.ts`: compute `totalAmount = pricePerHour × durationHours` inside `BookingsService.create()`.
- `bookings.dto.ts`: mark `totalAmount` as `@IsOptional()` so the validator no longer rejects requests that omit it.

---

### #208 — `verifyOtp` returns JWT tokens; frontend stores them

**Problem:** `auth.service.ts verifyOtp()` returned `{ message: 'Email verified successfully' }` with no token. The frontend redirected to `/dashboard` without a valid session, leaving the user unauthenticated.

**Fix:**
- `auth.service.ts`: after verifying the OTP, issue an `access_token` + `refresh_token` (same flow as `login()`).
- `verify-otp/page.tsx`: store the returned `access_token` as a `token` cookie and redirect to `/dashboard`.
- `apiClient.ts`: update `verifyOtp` return type to `{ access_token, refresh_token }`.

---

### #203 — Wire dashboard components to real API endpoints

**Problem:** `dashboard.service.ts getActivity()` returned `{ type, description, timestamp }` but `ActivityFeed` expected `{ id, icon, description, timestamp }`. `AdminOverview` queried `/dashboard/stats` which does not include admin-only fields (`totalBookings`, `revenue`).

**Fix:**
- `dashboard.service.ts`: `getActivity()` now returns `id` and `icon` fields.
- `AdminOverview.tsx`: call `/dashboard/admin-stats` instead of `/dashboard/stats`.

---

## Files changed

| File | Change |
|------|--------|
| `backend/src/auth/auth.service.ts` | `verifyOtp()` issues JWT + refresh token |
| `backend/src/bookings/bookings.dto.ts` | `totalAmount` made optional |
| `backend/src/bookings/bookings.service.ts` | `totalAmount` calculated server-side |
| `backend/src/dashboard/dashboard.service.ts` | `getActivity()` returns `id` + `icon` |
| `frontend/middleware.ts` | Expiry check added; role check consolidated |
| `frontend/src/app/(auth)/verify-otp/page.tsx` | Stores token cookie after OTP verification |
| `frontend/src/components/dashboard/AdminOverview.tsx` | Calls `/dashboard/admin-stats` |
| `frontend/src/lib/apiClient.ts` | `verifyOtp` return type updated |
| `frontend/src/lib/store/authStore.ts` | Sets/clears `token` cookie on auth state changes |

Closes #203
Closes #206
Closes #207
Closes #208