### PR TITLE
fix: resolve bugs #218 #219 #220 #221 across contracts, frontend, and backend

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -13,6 +13,7 @@ import {
   Req,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
 import {
   ApiTags,
   ApiOperation,
@@ -117,7 +118,7 @@ export class UsersController {
   }
 
   @Post(':id/profile-picture')
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() }))
   @ApiOperation({ summary: 'Upload profile picture' })
   @ApiParam({ name: 'id', type: String, description: 'User ID' })
   @ApiResponse({ status: 200, description: 'Profile picture uploaded successfully' })

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
     "hubassist_hub",
+    "manage_hub",
     "workspace_booking",
-    "membership_token",
     "access_control",
+    "membership_token",
     "payment_escrow",
     "common_types",
-    "manage_hub",
 ]
 resolver = "2"
 

--- a/contracts/hubassist_hub/src/lib.rs
+++ b/contracts/hubassist_hub/src/lib.rs
@@ -1,5 +1,12 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, String, Vec};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum HubError {
+    MemberAlreadyRegistered = 1,
+}
 
 #[contracttype]
 #[derive(Clone)]
@@ -29,15 +36,23 @@ impl HubAssistHub {
     }
 
     /// Register a new member.
-    pub fn register_member(env: Env, caller: Address, role: String) {
+    pub fn register_member(env: Env, caller: Address, role: String) -> Result<(), HubError> {
         caller.require_auth();
         let mut members: Vec<Member> = env
             .storage()
             .instance()
             .get(&DataKey::Members)
             .unwrap_or(Vec::new(&env));
+
+        for i in 0..members.len() {
+            if members.get(i).unwrap().address == caller {
+                return Err(HubError::MemberAlreadyRegistered);
+            }
+        }
+
         members.push_back(Member { address: caller, role, active: true });
         env.storage().instance().set(&DataKey::Members, &members);
+        Ok(())
     }
 
     /// Return total member count.

--- a/frontend/src/hooks/useLoginUser.ts
+++ b/frontend/src/hooks/useLoginUser.ts
@@ -2,10 +2,15 @@
 
 import { useMutation } from "@tanstack/react-query";
 import { post } from "@/lib/apiClient";
+import { useAuthStore } from "@/lib/store/authStore";
 
 export function useLoginUser() {
   return useMutation({
     mutationFn: ({ email, password }: { email: string; password: string }) =>
-      post<{ access_token: string }>("/auth/login", { email, password }),
+      post<{ access_token: string; user?: import("@/types/user").User }>("/auth/login", { email, password }),
+    onSuccess: (data) => {
+      useAuthStore.getState().login({ access_token: data.access_token, user: data.user });
+      window.location.href = "/dashboard";
+    },
   });
 }


### PR DESCRIPTION
## Summary

- **#218** — `hubassist_hub` contract: `register_member` now checks for duplicate registration before inserting, returning `HubError::MemberAlreadyRegistered` if the caller is already a member.
- **#219** — `useLoginUser` hook: wired `onSuccess` to call `useAuthStore.getState().login()` with the returned `access_token` and `user`, then redirects to `/dashboard`.
- **#220** — `contracts/Cargo.toml`: verified all workspace crates are listed (`payment_escrow`, `common_types`, and all others); reordered to canonical order.
- **#221** — `users.controller.ts`: configured `FileInterceptor` with `{ storage: memoryStorage() }` so uploaded files land in memory as a buffer, which is what `CloudinaryService.uploadImage` expects.

## Changes

### `contracts/hubassist_hub/src/lib.rs`
- Added `HubError` contracterror enum (`MemberAlreadyRegistered = 1`)
- Changed `register_member` signature to `-> Result<(), HubError>`
- Added duplicate-address check by iterating the members Vec before push

### `frontend/src/hooks/useLoginUser.ts`
- Imported `useAuthStore`
- Added `onSuccess` handler: calls `useAuthStore.getState().login(...)` and redirects to `/dashboard`

### `contracts/Cargo.toml`
- Reordered `[workspace] members` to canonical order; all crates confirmed present

### `backend/src/users/users.controller.ts`
- Imported `memoryStorage` from `multer`
- Passed `{ storage: memoryStorage() }` to `FileInterceptor('file', ...)` to ensure `file.buffer` is populated for Cloudinary uploads

## Test plan
- [ ] Call `register_member` twice for the same address — second call must return `MemberAlreadyRegistered` error
- [ ] Log in via the frontend — auth store should be populated and browser should redirect to `/dashboard`
- [ ] Run `cargo build` from `contracts/` root — all workspace crates compile
- [ ] Upload a profile picture — Cloudinary should receive the buffer without a temp-file path error

Closes #218
Closes #219
Closes #220
Closes #221