### PR TITLE
feat(backend): add global input sanitization pipeline and OTP flood protection

### DIFF
--- a/backend/src/auth/auth-otp-flood.service.spec.ts
+++ b/backend/src/auth/auth-otp-flood.service.spec.ts
@@ -1,0 +1,393 @@
+/**
+ * Unit tests for OTP flood protection:
+ *  - Sliding-window resend rate limiting (3 per 5 minutes)
+ *  - Wrong-attempt counter and OTP invalidation after 3 failures
+ *  - attemptsRemaining in error responses
+ *  - Integration: after invalidation, resend generates a new OTP that works
+ */
+
+import { BadRequestException, TooManyRequestsException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { OtpRateLimitService, OTP_RESEND_WINDOW_MS } from './otp-rate-limit.service';
+
+// ---------------------------------------------------------------------------
+// Minimal mock factories
+// ---------------------------------------------------------------------------
+
+const makeUser = (overrides: Record<string, unknown> = {}) => ({
+  id: 'user-1',
+  email: 'test@example.com',
+  otp: '$2b$10$hashedOtp',
+  otpExpiry: new Date(Date.now() + 10 * 60 * 1000), // 10 min from now
+  otpAttempts: 0,
+  otpInvalidatedAt: undefined as Date | undefined,
+  otpResendCount: 0,
+  isVerified: false,
+  role: 'member',
+  passwordHash: 'hash',
+  ...overrides,
+});
+
+const makeUsersService = (user: ReturnType<typeof makeUser>) => ({
+  findByEmail: jest.fn().mockResolvedValue(user),
+  update: jest.fn().mockImplementation((_id: string, data: Record<string, unknown>) => {
+    Object.assign(user, data);
+    return Promise.resolve(user);
+  }),
+});
+
+const makeJwtService = () => ({
+  sign: jest.fn().mockReturnValue('jwt-token'),
+});
+
+const makeEmailService = () => ({
+  sendVerificationOtp: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeRefreshTokenRepo = () => ({
+  create: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeNotificationsService = () => ({
+  sendToAll: jest.fn(),
+});
+
+// OtpRateLimitService mock — controls sliding-window behaviour per test
+const makeOtpRateLimitService = (
+  allowed = true,
+  remaining = 2,
+  retryAfterSeconds = 0,
+): jest.Mocked<OtpRateLimitService> =>
+  ({
+    checkAndRecordResend: jest.fn().mockResolvedValue({ allowed, remaining, retryAfterSeconds }),
+    clearResendWindow: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<OtpRateLimitService>);
+
+// bcrypt mock — avoids slow hashing in unit tests
+jest.mock('bcrypt', () => ({
+  hash: jest.fn().mockResolvedValue('$2b$10$hashedOtp'),
+  compare: jest.fn(),
+}));
+
+import * as bcrypt from 'bcrypt';
+
+// ---------------------------------------------------------------------------
+// Helper to build AuthService with injected mocks
+// ---------------------------------------------------------------------------
+
+function buildService(
+  user: ReturnType<typeof makeUser>,
+  rateLimitOverrides?: Partial<{ allowed: boolean; remaining: number; retryAfterSeconds: number }>,
+) {
+  const usersService = makeUsersService(user);
+  const jwtService = makeJwtService();
+  const emailService = makeEmailService();
+  const refreshTokenRepo = makeRefreshTokenRepo();
+  const notificationsService = makeNotificationsService();
+  const rateLimitService = makeOtpRateLimitService(
+    rateLimitOverrides?.allowed ?? true,
+    rateLimitOverrides?.remaining ?? 2,
+    rateLimitOverrides?.retryAfterSeconds ?? 0,
+  );
+
+  const service = new AuthService(
+    usersService as any,
+    jwtService as any,
+    emailService as any,
+    refreshTokenRepo as any,
+    null as any, // forgotPasswordProvider
+    null as any, // resetPasswordProvider
+    notificationsService as any,
+    rateLimitService,
+  );
+
+  return { service, usersService, emailService, rateLimitService };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: resendOtp — sliding-window rate limiting
+// ---------------------------------------------------------------------------
+
+describe('AuthService.resendOtp — sliding-window rate limiting', () => {
+  it('allows the first 3 resend requests within 5 minutes', async () => {
+    const user = makeUser();
+    const { service } = buildService(user, { allowed: true, remaining: 2 });
+
+    const result = await service.resendOtp(user.email);
+    expect(result.message).toBe('OTP resent to your email');
+  });
+
+  it('returns 429 on the 4th resend within 5 minutes', async () => {
+    const user = makeUser({ otpResendCount: 3 });
+    const { service } = buildService(user, {
+      allowed: false,
+      remaining: 0,
+      retryAfterSeconds: 180,
+    });
+
+    await expect(service.resendOtp(user.email)).rejects.toThrow(TooManyRequestsException);
+  });
+
+  it('includes retryAfterSeconds in the 429 response', async () => {
+    const user = makeUser({ otpResendCount: 3 });
+    const { service } = buildService(user, {
+      allowed: false,
+      remaining: 0,
+      retryAfterSeconds: 240,
+    });
+
+    try {
+      await service.resendOtp(user.email);
+      fail('Expected TooManyRequestsException');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(TooManyRequestsException);
+      expect(err.response?.retryAfterSeconds).toBe(240);
+    }
+  });
+
+  it('resets otpAttempts and otpInvalidatedAt when a new OTP is issued', async () => {
+    const user = makeUser({ otpAttempts: 2, otpInvalidatedAt: new Date() });
+    const { service, usersService } = buildService(user, { allowed: true, remaining: 1 });
+
+    await service.resendOtp(user.email);
+
+    const updateCall = usersService.update.mock.calls[0][1];
+    expect(updateCall.otpAttempts).toBe(0);
+    expect(updateCall.otpInvalidatedAt).toBeUndefined();
+  });
+
+  it('increments otpResendCount on each allowed resend', async () => {
+    const user = makeUser({ otpResendCount: 1 });
+    const { service, usersService } = buildService(user, { allowed: true, remaining: 1 });
+
+    await service.resendOtp(user.email);
+
+    const updateCall = usersService.update.mock.calls[0][1];
+    expect(updateCall.otpResendCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: verifyOtp — wrong-attempt counter and invalidation
+// ---------------------------------------------------------------------------
+
+describe('AuthService.verifyOtp — wrong-attempt counter and invalidation', () => {
+  beforeEach(() => {
+    (bcrypt.compare as jest.Mock).mockReset();
+  });
+
+  it('returns attemptsRemaining on first wrong guess', async () => {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+    const user = makeUser({ otpAttempts: 0 });
+    const { service } = buildService(user);
+
+    try {
+      await service.verifyOtp(user.email, '000000');
+      fail('Expected BadRequestException');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(BadRequestException);
+      expect(err.response?.attemptsRemaining).toBe(2);
+    }
+  });
+
+  it('returns attemptsRemaining=1 on second wrong guess', async () => {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+    const user = makeUser({ otpAttempts: 1 });
+    const { service } = buildService(user);
+
+    try {
+      await service.verifyOtp(user.email, '000000');
+      fail('Expected BadRequestException');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(BadRequestException);
+      expect(err.response?.attemptsRemaining).toBe(1);
+    }
+  });
+
+  it('invalidates OTP after 3 wrong guesses', async () => {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+    const user = makeUser({ otpAttempts: 2 }); // 3rd attempt
+    const { service, usersService } = buildService(user);
+
+    try {
+      await service.verifyOtp(user.email, '000000');
+      fail('Expected BadRequestException');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(BadRequestException);
+      expect(err.response?.attemptsRemaining).toBe(0);
+      expect(err.response?.message).toContain('invalidated');
+    }
+
+    // otpInvalidatedAt must be set
+    const updateCall = usersService.update.mock.calls[0][1];
+    expect(updateCall.otpInvalidatedAt).toBeInstanceOf(Date);
+  });
+
+  it('rejects correct OTP after invalidation', async () => {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true); // correct OTP
+    const user = makeUser({ otpInvalidatedAt: new Date() });
+    const { service } = buildService(user);
+
+    await expect(service.verifyOtp(user.email, '123456')).rejects.toThrow(BadRequestException);
+
+    try {
+      await service.verifyOtp(user.email, '123456');
+    } catch (err: any) {
+      expect(err.response?.attemptsRemaining).toBe(0);
+      expect(err.response?.message).toContain('invalidated');
+    }
+  });
+
+  it('never exposes the OTP value in error responses', async () => {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+    const user = makeUser({ otpAttempts: 0 });
+    const { service } = buildService(user);
+
+    try {
+      await service.verifyOtp(user.email, '000000');
+    } catch (err: any) {
+      const responseStr = JSON.stringify(err.response ?? {});
+      // The stored hash must never appear in the response
+      expect(responseStr).not.toContain('$2b$10$hashedOtp');
+      // The submitted OTP must never be echoed back
+      expect(responseStr).not.toContain('000000');
+    }
+  });
+
+  it('clears all OTP state on successful verification', async () => {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    const user = makeUser({ otpAttempts: 1 });
+    const { service, usersService, rateLimitService } = buildService(user);
+
+    await service.verifyOtp(user.email, '123456');
+
+    const updateCall = usersService.update.mock.calls[0][1];
+    expect(updateCall.isVerified).toBe(true);
+    expect(updateCall.otp).toBeUndefined();
+    expect(updateCall.otpExpiry).toBeUndefined();
+    expect(updateCall.otpAttempts).toBe(0);
+    expect(updateCall.otpInvalidatedAt).toBeUndefined();
+    expect(updateCall.otpResendCount).toBe(0);
+
+    // Redis window must be cleared
+    expect(rateLimitService.clearResendWindow).toHaveBeenCalledWith(user.email);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: invalidation → resend → new OTP works
+// ---------------------------------------------------------------------------
+
+describe('AuthService — integration: invalidation then resend', () => {
+  it('after invalidation, resend generates a new OTP that can be verified', async () => {
+    // Step 1: OTP is invalidated
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+    const user = makeUser({ otpAttempts: 2 });
+    const { service: svc1, usersService: us1 } = buildService(user);
+
+    try {
+      await svc1.verifyOtp(user.email, '000000');
+    } catch {
+      // expected — OTP invalidated
+    }
+
+    expect(user.otpInvalidatedAt).toBeInstanceOf(Date);
+
+    // Step 2: User requests a new OTP via resend
+    const { service: svc2, usersService: us2 } = buildService(user, {
+      allowed: true,
+      remaining: 2,
+    });
+
+    const resendResult = await svc2.resendOtp(user.email);
+    expect(resendResult.message).toBe('OTP resent to your email');
+
+    // otpInvalidatedAt and otpAttempts must be reset
+    const resendUpdate = us2.update.mock.calls[0][1];
+    expect(resendUpdate.otpAttempts).toBe(0);
+    expect(resendUpdate.otpInvalidatedAt).toBeUndefined();
+
+    // Step 3: Verify with the new OTP (simulate correct hash)
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    // Simulate the user entity after resend (no invalidation)
+    const freshUser = makeUser({ otpAttempts: 0, otpInvalidatedAt: undefined });
+    const { service: svc3 } = buildService(freshUser);
+
+    const verifyResult = await svc3.verifyOtp(freshUser.email, '654321');
+    expect(verifyResult).toHaveProperty('access_token');
+    expect(verifyResult).toHaveProperty('refresh_token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: OtpRateLimitService — sliding window expiry
+// ---------------------------------------------------------------------------
+
+describe('OtpRateLimitService — sliding window', () => {
+  it('allows up to OTP_RESEND_LIMIT requests within the window', async () => {
+    const mockCache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const svc = new OtpRateLimitService(mockCache as any);
+
+    // Simulate 3 timestamps all within the window
+    const now = Date.now();
+    const timestamps = [now - 1000, now - 2000]; // 2 existing
+    mockCache.get.mockResolvedValue(JSON.stringify(timestamps));
+
+    const result = await svc.checkAndRecordResend('user@example.com');
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(0); // 3rd slot used
+  });
+
+  it('blocks the 4th request within the window', async () => {
+    const mockCache = {
+      get: jest.fn(),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const svc = new OtpRateLimitService(mockCache as any);
+
+    const now = Date.now();
+    // 3 timestamps all within the 5-minute window
+    const timestamps = [now - 60_000, now - 120_000, now - 180_000];
+    mockCache.get.mockResolvedValue(JSON.stringify(timestamps));
+
+    const result = await svc.checkAndRecordResend('user@example.com');
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it('allows a new request after the window expires (old timestamps evicted)', async () => {
+    const mockCache = {
+      get: jest.fn(),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const svc = new OtpRateLimitService(mockCache as any);
+
+    const now = Date.now();
+    // 3 timestamps all OUTSIDE the 5-minute window (expired)
+    const expired = [
+      now - OTP_RESEND_WINDOW_MS - 1000,
+      now - OTP_RESEND_WINDOW_MS - 2000,
+      now - OTP_RESEND_WINDOW_MS - 3000,
+    ];
+    mockCache.get.mockResolvedValue(JSON.stringify(expired));
+
+    const result = await svc.checkAndRecordResend('user@example.com');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('falls back gracefully when cache is unavailable', async () => {
+    const svc = new OtpRateLimitService(null);
+    const result = await svc.checkAndRecordResend('user@example.com');
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -17,6 +17,7 @@ import { ForgotPasswordProvider } from '../users/providers/forgot-password.provi
 import { ResetPasswordProvider } from '../users/providers/reset-password.provider';
 import { User } from '../users/user.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { OtpRateLimitService } from './otp-rate-limit.service';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     RefreshTokenRepository,
     ForgotPasswordProvider,
     ResetPasswordProvider,
+    OtpRateLimitService,
   ],
   controllers: [AuthController, BiometricController],
 })

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, BadRequestException, TooManyRequestsException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { randomBytes, randomUUID } from 'crypto';
@@ -8,6 +8,7 @@ import { RefreshTokenRepository } from './refresh-token.repository';
 import { ForgotPasswordProvider } from '../users/providers/forgot-password.provider';
 import { ResetPasswordProvider } from '../users/providers/reset-password.provider';
 import { NotificationsService } from '../notifications/notifications.service';
+import { OtpRateLimitService, OTP_MAX_ATTEMPTS, OTP_RESEND_LIMIT } from './otp-rate-limit.service';
 
 @Injectable()
 export class AuthService {
@@ -19,6 +20,7 @@ export class AuthService {
     private forgotPasswordProvider: ForgotPasswordProvider,
     private resetPasswordProvider: ResetPasswordProvider,
     private notificationsService: NotificationsService,
+    private otpRateLimitService: OtpRateLimitService,
   ) {}
 
   private generateOtp(): string {
@@ -83,20 +85,57 @@ export class AuthService {
       throw new BadRequestException('No OTP found for this user');
     }
 
+    // Reject if the OTP was already invalidated by too many wrong guesses
+    if (user.otpInvalidatedAt) {
+      throw new BadRequestException({
+        message: 'OTP has been invalidated due to too many wrong attempts. Please request a new OTP.',
+        attemptsRemaining: 0,
+      });
+    }
+
     if (new Date() > user.otpExpiry) {
       throw new BadRequestException('OTP has expired');
     }
 
     const isValid = await this.verifyOtpHash(otp, user.otp);
+
     if (!isValid) {
-      throw new BadRequestException('Invalid OTP');
+      const newAttempts = (user.otpAttempts ?? 0) + 1;
+      const attemptsRemaining = Math.max(0, OTP_MAX_ATTEMPTS - newAttempts);
+
+      if (newAttempts >= OTP_MAX_ATTEMPTS) {
+        // Invalidate the OTP — brute-force threshold reached
+        await this.usersService.update(user.id, {
+          otpAttempts: newAttempts,
+          otpInvalidatedAt: new Date(),
+        });
+        throw new BadRequestException({
+          message: 'OTP has been invalidated due to too many wrong attempts. Please request a new OTP.',
+          attemptsRemaining: 0,
+        });
+      }
+
+      // Record the failed attempt
+      await this.usersService.update(user.id, { otpAttempts: newAttempts });
+
+      throw new BadRequestException({
+        message: 'Invalid OTP',
+        attemptsRemaining,
+      });
     }
 
+    // Successful verification — clear all OTP state
     await this.usersService.update(user.id, {
       isVerified: true,
       otp: undefined,
       otpExpiry: undefined,
+      otpAttempts: 0,
+      otpInvalidatedAt: undefined,
+      otpResendCount: 0,
     });
+
+    // Clear the Redis sliding window for this user
+    await this.otpRateLimitService.clearResendWindow(email);
 
     const refreshToken = this.generateRefreshToken();
     const refreshTokenHash = await this.hashRefreshToken(refreshToken);
@@ -116,11 +155,26 @@ export class AuthService {
       throw new BadRequestException('User not found');
     }
 
-    // Rate limit: only resend if previous OTP is expired or doesn't exist
-    if (user.otp && user.otpExpiry && new Date() < user.otpExpiry) {
-      throw new BadRequestException('OTP already sent. Please wait before requesting a new one.');
+    // ── Sliding-window rate limit (Redis primary, DB fallback) ──────────────
+    const rateLimitResult = await this.otpRateLimitService.checkAndRecordResend(email);
+
+    if (!rateLimitResult.allowed) {
+      throw new TooManyRequestsException({
+        message: `Too many OTP resend requests. Please wait ${rateLimitResult.retryAfterSeconds} seconds before trying again.`,
+        retryAfterSeconds: rateLimitResult.retryAfterSeconds,
+      });
     }
 
+    // DB-level fallback: if Redis was unavailable, enforce via DB counter
+    // (OTP_RESEND_LIMIT resends tracked by otpResendCount, reset on successful verify)
+    if (rateLimitResult.redisUnavailable && user.otpResendCount >= OTP_RESEND_LIMIT) {
+      throw new TooManyRequestsException({
+        message: 'Too many OTP resend requests. Please try again later.',
+        retryAfterSeconds: 300,
+      });
+    }
+
+    // Generate a fresh OTP and reset all attempt counters
     const otp = this.generateOtp();
     const otpHash = await this.hashOtp(otp);
     const otpExpiry = new Date(Date.now() + 10 * 60 * 1000);
@@ -128,13 +182,19 @@ export class AuthService {
     await this.usersService.update(user.id, {
       otp: otpHash,
       otpExpiry,
+      otpAttempts: 0,
+      otpInvalidatedAt: undefined,
+      otpResendCount: (user.otpResendCount ?? 0) + 1,
     });
 
     this.emailService.sendVerificationOtp(email, otp).catch(err => {
       console.error('Failed to send OTP email:', err);
     });
 
-    return { message: 'OTP resent to your email' };
+    return {
+      message: 'OTP resent to your email',
+      resendsRemaining: rateLimitResult.remaining,
+    };
   }
 
   async login(email: string, password: string) {

--- a/backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,6 +1,12 @@
 import { IsString } from 'class-validator';
+import { NoSanitize } from '../../common/decorators/no-sanitize.decorator';
 
 export class RefreshTokenDto {
+  /**
+   * Refresh tokens are UUIDs — must not be trimmed or altered by the
+   * sanitization pipeline, as any modification would invalidate the token.
+   */
+  @NoSanitize()
   @IsString()
   refreshToken!: string;
 }

--- a/backend/src/auth/dto/reset-password.dto.ts
+++ b/backend/src/auth/dto/reset-password.dto.ts
@@ -1,9 +1,15 @@
 import { IsEmail, IsString, Length, Matches } from 'class-validator';
+import { NoSanitize } from '../../common/decorators/no-sanitize.decorator';
 
 export class ResetPasswordDto {
   @IsEmail()
   email!: string;
 
+  /**
+   * OTP is a 6-digit numeric code — must not be altered by the sanitization
+   * pipeline, as any modification would cause verification failure.
+   */
+  @NoSanitize()
   @IsString()
   @Length(6, 6)
   otp!: string;

--- a/backend/src/auth/dto/verify-otp.dto.ts
+++ b/backend/src/auth/dto/verify-otp.dto.ts
@@ -1,9 +1,15 @@
 import { IsEmail, IsString, Length } from 'class-validator';
+import { NoSanitize } from '../../common/decorators/no-sanitize.decorator';
 
 export class VerifyOtpDto {
   @IsEmail()
   email!: string;
 
+  /**
+   * OTP is a 6-digit numeric code — must not be trimmed or altered by the
+   * sanitization pipeline, as any modification would cause verification failure.
+   */
+  @NoSanitize()
   @IsString()
   @Length(6, 6)
   otp!: string;

--- a/backend/src/auth/otp-rate-limit.service.ts
+++ b/backend/src/auth/otp-rate-limit.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger, Inject, Optional } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+
+/** Maximum OTP resend requests allowed within the sliding window. */
+export const OTP_RESEND_LIMIT = 3;
+
+/** Sliding-window duration in milliseconds (5 minutes). */
+export const OTP_RESEND_WINDOW_MS = 5 * 60 * 1000;
+
+/** Maximum wrong OTP guesses before the OTP is invalidated. */
+export const OTP_MAX_ATTEMPTS = 3;
+
+export interface ResendCheckResult {
+  /** Whether the resend is allowed. */
+  allowed: boolean;
+  /** How many resends remain in the current window (only meaningful when allowed). */
+  remaining: number;
+  /** Seconds until the oldest request in the window expires (only meaningful when blocked). */
+  retryAfterSeconds: number;
+  /** True when Redis was unavailable and the caller should apply DB-level fallback. */
+  redisUnavailable?: boolean;
+}
+
+/**
+ * Manages per-user OTP rate-limit state using a Redis sliding window.
+ * Falls back to a simple DB-level counter when Redis is unavailable.
+ *
+ * Redis key: `otp:resend:<email>`
+ * Value: JSON array of ISO timestamp strings representing each resend event.
+ * TTL: OTP_RESEND_WINDOW_MS (auto-expires stale windows).
+ */
+@Injectable()
+export class OtpRateLimitService {
+  private readonly logger = new Logger(OtpRateLimitService.name);
+
+  constructor(
+    @Optional() @Inject(CACHE_MANAGER) private readonly cache: Cache | null,
+  ) {}
+
+  // ── Sliding-window resend check ──────────────────────────────────────────
+
+  /**
+   * Check whether a resend is allowed for the given email.
+   * Records the new resend timestamp if allowed.
+   */
+  async checkAndRecordResend(email: string): Promise<ResendCheckResult> {
+    if (!this.cache) {
+      // Redis unavailable — caller must use DB-level counter fallback
+      this.logger.warn('Cache unavailable; OTP resend rate-limit falling back to DB counter');
+      return { allowed: true, remaining: OTP_RESEND_LIMIT - 1, retryAfterSeconds: 0, redisUnavailable: true };
+    }
+
+    const key = this.buildKey(email);
+    const now = Date.now();
+    const windowStart = now - OTP_RESEND_WINDOW_MS;
+
+    // Load existing timestamps
+    let timestamps: number[] = await this.loadTimestamps(key);
+
+    // Evict entries outside the sliding window
+    timestamps = timestamps.filter((ts) => ts > windowStart);
+
+    if (timestamps.length >= OTP_RESEND_LIMIT) {
+      // Oldest entry determines when the window opens up
+      const oldestTs = Math.min(...timestamps);
+      const retryAfterMs = oldestTs + OTP_RESEND_WINDOW_MS - now;
+      const retryAfterSeconds = Math.ceil(retryAfterMs / 1000);
+
+      this.logger.warn(
+        `OTP resend rate-limit exceeded for ${email}: ${timestamps.length}/${OTP_RESEND_LIMIT} in window`,
+      );
+
+      return { allowed: false, remaining: 0, retryAfterSeconds };
+    }
+
+    // Record this resend
+    timestamps.push(now);
+    await this.saveTimestamps(key, timestamps);
+
+    return {
+      allowed: true,
+      remaining: OTP_RESEND_LIMIT - timestamps.length,
+      retryAfterSeconds: 0,
+    };
+  }
+
+  /**
+   * Clear the sliding-window state for a user (e.g. after successful verification).
+   */
+  async clearResendWindow(email: string): Promise<void> {
+    if (!this.cache) return;
+    try {
+      await this.cache.del(this.buildKey(email));
+    } catch (err) {
+      this.logger.warn(`Failed to clear OTP resend window for ${email}: ${err}`);
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private buildKey(email: string): string {
+    return `otp:resend:${email}`;
+  }
+
+  private async loadTimestamps(key: string): Promise<number[]> {
+    try {
+      const raw = await this.cache!.get<string>(key);
+      if (!raw) return [];
+      return JSON.parse(raw) as number[];
+    } catch (err) {
+      this.logger.warn(`Failed to load OTP timestamps from cache: ${err}`);
+      return [];
+    }
+  }
+
+  private async saveTimestamps(key: string, timestamps: number[]): Promise<void> {
+    try {
+      // TTL = window duration so Redis auto-cleans stale keys
+      await this.cache!.set(key, JSON.stringify(timestamps), OTP_RESEND_WINDOW_MS);
+    } catch (err) {
+      this.logger.warn(`Failed to save OTP timestamps to cache: ${err}`);
+    }
+  }
+}

--- a/backend/src/common/decorators/no-sanitize.decorator.ts
+++ b/backend/src/common/decorators/no-sanitize.decorator.ts
@@ -1,0 +1,21 @@
+import 'reflect-metadata';
+
+/**
+ * Mark a DTO property as exempt from the global sanitization pipeline.
+ * Use this for fields whose values must not be altered before storage,
+ * such as hash values, tokens, or raw binary data.
+ *
+ * @example
+ * class RefreshTokenDto {
+ *   @NoSanitize()
+ *   @IsString()
+ *   refreshToken: string;
+ * }
+ */
+export const NO_SANITIZE_KEY = 'hubassist:noSanitize';
+
+export function NoSanitize(): PropertyDecorator {
+  return (target: object, propertyKey: string | symbol) => {
+    Reflect.defineMetadata(NO_SANITIZE_KEY, true, target, propertyKey);
+  };
+}

--- a/backend/src/common/pipes/sanitization.pipe.spec.ts
+++ b/backend/src/common/pipes/sanitization.pipe.spec.ts
@@ -1,0 +1,137 @@
+import 'reflect-metadata';
+import { ArgumentMetadata } from '@nestjs/common';
+import { SanitizationPipe } from './sanitization.pipe';
+import { NoSanitize } from '../decorators/no-sanitize.decorator';
+
+// ---------------------------------------------------------------------------
+// Helper DTOs used across tests
+// ---------------------------------------------------------------------------
+
+class UserDto {
+  name!: string;
+  email!: string;
+}
+
+class SearchDto {
+  query!: string;
+}
+
+class TokenDto {
+  @NoSanitize()
+  refreshToken!: string;
+
+  name!: string;
+}
+
+// ---------------------------------------------------------------------------
+
+describe('SanitizationPipe', () => {
+  let pipe: SanitizationPipe;
+
+  beforeEach(() => {
+    pipe = new SanitizationPipe();
+  });
+
+  const bodyMeta = (metatype: new (...args: unknown[]) => unknown): ArgumentMetadata => ({
+    type: 'body',
+    metatype,
+    data: '',
+  });
+
+  // ── XSS / HTML stripping ──────────────────────────────────────────────────
+
+  it('strips XSS payload from name field → empty string', () => {
+    const value = { name: '<script>alert(1)</script>', email: 'a@b.com' };
+    const result = pipe.transform(value, bodyMeta(UserDto)) as Record<string, unknown>;
+    // The script tags are stripped; only the inner text remains — which is empty here
+    expect(result.name).toBe('alert(1)');
+  });
+
+  it('strips HTML tags leaving only inner text', () => {
+    const value = { name: '<b>John</b>', email: 'a@b.com' };
+    const result = pipe.transform(value, bodyMeta(UserDto)) as Record<string, unknown>;
+    expect(result.name).toBe('John');
+  });
+
+  it('strips a name field that is ONLY tags → empty string', () => {
+    const value = { name: '<img src=x onerror=alert(1)>', email: 'a@b.com' };
+    const result = pipe.transform(value, bodyMeta(UserDto)) as Record<string, unknown>;
+    expect(result.name).toBe('');
+  });
+
+  // ── SQL injection passthrough (sanitization ≠ escaping) ──────────────────
+
+  it('passes SQL injection string through unchanged (no HTML tags to strip)', () => {
+    // SQL injection does not contain HTML tags, so the value must be preserved
+    const sqlPayload = "' OR '1'='1"; // no angle brackets → no stripping
+    const value = { query: sqlPayload };
+    const result = pipe.transform(value, bodyMeta(SearchDto)) as Record<string, unknown>;
+    expect(result.query).toBe(sqlPayload);
+  });
+
+  it('trims whitespace from SQL injection string but preserves the payload', () => {
+    const sqlPayload = "  ' OR 1=1 --  ";
+    const value = { query: sqlPayload };
+    const result = pipe.transform(value, bodyMeta(SearchDto)) as Record<string, unknown>;
+    expect(result.query).toBe("' OR 1=1 --");
+  });
+
+  // ── Whitespace trimming ───────────────────────────────────────────────────
+
+  it('trims leading and trailing whitespace', () => {
+    const value = { name: '  Alice  ', email: 'a@b.com' };
+    const result = pipe.transform(value, bodyMeta(UserDto)) as Record<string, unknown>;
+    expect(result.name).toBe('Alice');
+  });
+
+  // ── Unicode normalization ─────────────────────────────────────────────────
+
+  it('normalizes unicode to NFC', () => {
+    // 'é' can be represented as U+00E9 (NFC) or U+0065 U+0301 (NFD)
+    const nfd = '\u0065\u0301'; // NFD form of é
+    const nfc = '\u00E9';       // NFC form of é
+    const value = { name: nfd, email: 'a@b.com' };
+    const result = pipe.transform(value, bodyMeta(UserDto)) as Record<string, unknown>;
+    expect(result.name).toBe(nfc);
+  });
+
+  // ── @NoSanitize() bypass ──────────────────────────────────────────────────
+
+  it('@NoSanitize() fields bypass the transformer', () => {
+    const rawToken = '  <script>token_value_abc123</script>  ';
+    const value = { refreshToken: rawToken, name: '  Alice  ' };
+    const result = pipe.transform(value, bodyMeta(TokenDto)) as Record<string, unknown>;
+    // refreshToken must be untouched
+    expect(result.refreshToken).toBe(rawToken);
+    // name must still be sanitized
+    expect(result.name).toBe('Alice');
+  });
+
+  // ── Non-string values ─────────────────────────────────────────────────────
+
+  it('leaves non-string values unchanged', () => {
+    const value = { count: 42, active: true, tags: ['a', 'b'] };
+    const result = pipe.transform(value, { type: 'body', metatype: undefined, data: '' }) as Record<string, unknown>;
+    expect(result.count).toBe(42);
+    expect(result.active).toBe(true);
+    expect(result.tags).toEqual(['a', 'b']);
+  });
+
+  it('returns null/undefined as-is', () => {
+    expect(pipe.transform(null, bodyMeta(UserDto))).toBeNull();
+    expect(pipe.transform(undefined, bodyMeta(UserDto))).toBeUndefined();
+  });
+
+  it('returns primitive strings as-is (not wrapped in object)', () => {
+    // Primitives are not objects — pipe should pass them through
+    expect(pipe.transform('  hello  ', bodyMeta(UserDto))).toBe('  hello  ');
+  });
+
+  // ── Combined XSS + whitespace ─────────────────────────────────────────────
+
+  it('trims and strips HTML in one pass', () => {
+    const value = { name: '  <div>  Bob  </div>  ', email: 'a@b.com' };
+    const result = pipe.transform(value, bodyMeta(UserDto)) as Record<string, unknown>;
+    expect(result.name).toBe('Bob');
+  });
+});

--- a/backend/src/common/pipes/sanitization.pipe.ts
+++ b/backend/src/common/pipes/sanitization.pipe.ts
@@ -1,0 +1,102 @@
+import {
+  Injectable,
+  PipeTransform,
+  ArgumentMetadata,
+  Logger,
+} from '@nestjs/common';
+import 'reflect-metadata';
+import { NO_SANITIZE_KEY } from '../decorators/no-sanitize.decorator';
+import { sanitizeStringValue } from '../transformers/sanitize-string.transformer';
+
+/**
+ * Global sanitization pipe — runs BEFORE the ValidationPipe.
+ *
+ * For every incoming DTO body/query/param:
+ *  - Iterates all string properties
+ *  - Trims whitespace, strips HTML tags, normalizes unicode (NFC)
+ *  - Skips properties decorated with @NoSanitize()
+ *  - Logs a WARN when a value was actually changed (field name + truncated original)
+ *
+ * Register in main.ts BEFORE ValidationPipe:
+ *   app.useGlobalPipes(new SanitizationPipe(), new ValidationPipe(...))
+ */
+@Injectable()
+export class SanitizationPipe implements PipeTransform {
+  private readonly logger = new Logger(SanitizationPipe.name);
+
+  transform(value: unknown, metadata: ArgumentMetadata): unknown {
+    // Only process body / query / param objects; skip raw primitives and files
+    if (
+      value === null ||
+      value === undefined ||
+      typeof value !== 'object' ||
+      Array.isArray(value)
+    ) {
+      return value;
+    }
+
+    // Resolve the DTO constructor so we can read its metadata
+    const metatype = metadata.metatype;
+
+    return this.sanitizeObject(value as Record<string, unknown>, metatype);
+  }
+
+  private sanitizeObject(
+    obj: Record<string, unknown>,
+    metatype?: new (...args: unknown[]) => unknown,
+  ): Record<string, unknown> {
+    const sanitized: Record<string, unknown> = { ...obj };
+
+    for (const key of Object.keys(sanitized)) {
+      const fieldValue = sanitized[key];
+
+      // Recursively handle nested plain objects
+      if (
+        fieldValue !== null &&
+        typeof fieldValue === 'object' &&
+        !Array.isArray(fieldValue)
+      ) {
+        sanitized[key] = this.sanitizeObject(
+          fieldValue as Record<string, unknown>,
+        );
+        continue;
+      }
+
+      if (typeof fieldValue !== 'string') {
+        continue;
+      }
+
+      // Check @NoSanitize() metadata on the DTO class property
+      if (metatype && this.isNoSanitize(metatype, key)) {
+        continue;
+      }
+
+      const cleaned = sanitizeStringValue(fieldValue);
+
+      if (cleaned !== fieldValue) {
+        // Log at warn level: field name + first 80 chars of original value
+        const truncated =
+          fieldValue.length > 80
+            ? `${fieldValue.slice(0, 80)}…`
+            : fieldValue;
+        this.logger.warn(
+          `Sanitized field "${key}": original value truncated → "${truncated}"`,
+        );
+        sanitized[key] = cleaned;
+      }
+    }
+
+    return sanitized;
+  }
+
+  /**
+   * Returns true when the property has been decorated with @NoSanitize().
+   * The decorator uses Reflect.defineMetadata on the class prototype.
+   */
+  private isNoSanitize(
+    metatype: new (...args: unknown[]) => unknown,
+    propertyKey: string,
+  ): boolean {
+    return Reflect.getMetadata(NO_SANITIZE_KEY, metatype.prototype, propertyKey) === true;
+  }
+}

--- a/backend/src/common/transformers/sanitize-string.transformer.spec.ts
+++ b/backend/src/common/transformers/sanitize-string.transformer.spec.ts
@@ -1,6 +1,6 @@
 import { plainToInstance } from 'class-transformer';
 import { IsString } from 'class-validator';
-import { SanitizeString } from './sanitize-string.transformer';
+import { SanitizeString, sanitizeStringValue } from './sanitize-string.transformer';
 
 class TestDto {
   @SanitizeString()
@@ -8,7 +8,7 @@ class TestDto {
   text!: string;
 }
 
-describe('SanitizeString Transformer', () => {
+describe('SanitizeString Transformer (decorator)', () => {
   it('should strip HTML tags', () => {
     const input = { text: '<script>alert("xss")</script>Hello' };
     const result = plainToInstance(TestDto, input);
@@ -31,5 +31,39 @@ describe('SanitizeString Transformer', () => {
     const input = { text: 123 };
     const result = plainToInstance(TestDto, input);
     expect(result.text).toBe(123);
+  });
+
+  it('should normalize unicode to NFC', () => {
+    const nfd = '\u0065\u0301'; // NFD é
+    const nfc = '\u00E9';       // NFC é
+    const input = { text: nfd };
+    const result = plainToInstance(TestDto, input);
+    expect(result.text).toBe(nfc);
+  });
+});
+
+describe('sanitizeStringValue (utility function)', () => {
+  it('trims whitespace', () => {
+    expect(sanitizeStringValue('  hello  ')).toBe('hello');
+  });
+
+  it('strips HTML tags', () => {
+    expect(sanitizeStringValue('<b>bold</b>')).toBe('bold');
+  });
+
+  it('strips self-closing tags', () => {
+    expect(sanitizeStringValue('<img src=x />')).toBe('');
+  });
+
+  it('normalizes unicode NFC', () => {
+    expect(sanitizeStringValue('\u0065\u0301')).toBe('\u00E9');
+  });
+
+  it('returns empty string for tag-only input', () => {
+    expect(sanitizeStringValue('<script></script>')).toBe('');
+  });
+
+  it('does not alter plain text', () => {
+    expect(sanitizeStringValue('hello world')).toBe('hello world');
   });
 });

--- a/backend/src/common/transformers/sanitize-string.transformer.ts
+++ b/backend/src/common/transformers/sanitize-string.transformer.ts
@@ -1,14 +1,31 @@
 import { Transform } from 'class-transformer';
 
+/**
+ * Per-field sanitization decorator (class-transformer).
+ * Trims whitespace, strips HTML tags, and normalizes unicode (NFC).
+ * Use @NoSanitize() instead when a field must bypass all sanitization.
+ */
 export function SanitizeString() {
   return Transform(({ value }) => {
     if (typeof value !== 'string') {
       return value;
     }
-    // Trim whitespace
-    let sanitized = value.trim();
-    // Strip HTML tags
-    sanitized = sanitized.replace(/<[^>]*>/g, '');
-    return sanitized;
+    return sanitizeStringValue(value);
   });
+}
+
+/**
+ * Core sanitization logic shared between the decorator and the global pipe.
+ * 1. Trim leading/trailing whitespace
+ * 2. Strip HTML tags (prevents XSS payloads)
+ * 3. Normalize unicode to NFC (prevents homoglyph / injection tricks)
+ */
+export function sanitizeStringValue(value: string): string {
+  // Trim whitespace
+  let sanitized = value.trim();
+  // Strip HTML tags
+  sanitized = sanitized.replace(/<[^>]*>/g, '');
+  // Normalize unicode to NFC
+  sanitized = sanitized.normalize('NFC');
+  return sanitized;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -10,6 +10,7 @@ import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './utils/error';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { SanitizationPipe } from './common/pipes/sanitization.pipe';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -36,7 +37,10 @@ async function bootstrap() {
   });
 
   // Global validation pipe
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  app.useGlobalPipes(
+    new SanitizationPipe(),
+    new ValidationPipe({ whitelist: true, transform: true }),
+  );
 
   // Global exception filter
   app.useGlobalFilters(new HttpExceptionFilter());

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -36,6 +36,31 @@ export class User {
   @Column({ type: 'timestamp', nullable: true })
   otpExpiry?: Date;
 
+  // ── OTP flood-protection fields ──────────────────────────────────────────
+
+  /**
+   * Number of consecutive wrong OTP guesses since the last OTP was issued.
+   * Reset to 0 when a new OTP is generated.
+   */
+  @Column({ default: 0 })
+  otpAttempts!: number;
+
+  /**
+   * Set when the OTP is invalidated after MAX_OTP_ATTEMPTS wrong guesses.
+   * A non-null value means the current OTP is no longer usable.
+   */
+  @Column({ type: 'timestamp', nullable: true })
+  otpInvalidatedAt?: Date;
+
+  /**
+   * Total number of OTP resend requests made by this user.
+   * Used as a DB-level fallback counter when Redis is unavailable.
+   */
+  @Column({ default: 0 })
+  otpResendCount!: number;
+
+  // ── End OTP flood-protection fields ──────────────────────────────────────
+
    @Column({ default: false })
    isVerified: boolean;
 


### PR DESCRIPTION


close #289 


closes #296

## What

Two security features added to the backend:

### A — Global Input Sanitization Pipeline
- Added `SanitizationPipe` registered globally before `ValidationPipe` in `main.ts`
- Trims whitespace, strips HTML tags, and normalizes unicode (NFC) on all incoming string fields
- Added `@NoSanitize()` property decorator for fields that must bypass sanitization (tokens, OTP codes)
- Applied `@NoSanitize()` to `otp` and `refreshToken` DTO fields
- Logs a WARN with truncated original value whenever a field is sanitized
- Extracted `sanitizeStringValue()` as a shared utility used by both the pipe and the existing `@SanitizeString()` decorator

### B — OTP Flood Protection (sliding window + wrong-attempt invalidation)
- Added `OtpRateLimitService` with Redis sliding-window rate limiting: 3 resends per 5-minute window per user (by email, not IP)
- Falls back to DB counter (`otpResendCount`) when Redis is unavailable
- Wrong OTP guesses now increment `otpAttempts`; at 3 failures the OTP is invalidated via `otpInvalidatedAt`
- Every failed `verify-otp` response includes `attemptsRemaining`
- OTP value is never exposed in any error response
- All OTP state is cleared on successful verification; Redis window is also cleared
- Added `otpAttempts`, `otpInvalidatedAt`, `otpResendCount` columns to the `users` table

## Tests

- `sanitization.pipe.spec.ts` — XSS stripping, SQL injection passthrough, `@NoSanitize()` bypass, unicode NFC, whitespace trim
- `sanitize-string.transformer.spec.ts` — updated to cover `sanitizeStringValue()` and NFC normalization
- `auth-otp-flood.service.spec.ts` — sliding window expiry, 4th resend → 429, wrong-attempt counter, OTP invalidation, correct OTP rejected after invalidation, full state cleared on success, Redis fallback

## Files Changed

- `src/main.ts`
- `src/users/user.entity.ts`
- `src/auth/auth.service.ts`
- `src/auth/auth.module.ts`
- `src/auth/otp-rate-limit.service.ts` *(new)*
- `src/auth/auth-otp-flood.service.spec.ts` *(new)*
- `src/auth/dto/verify-otp.dto.ts`
- `src/auth/dto/refresh-token.dto.ts`
- `src/auth/dto/reset-password.dto.ts`
- `src/common/pipes/sanitization.pipe.ts` *(new)*
- `src/common/pipes/sanitization.pipe.spec.ts` *(new)*
- `src/common/decorators/no-sanitize.decorator.ts` *(new)*
- `src/common/transformers/sanitize-string.transformer.ts`
- `src/common/transformers/sanitize-string.transformer.spec.ts`
