### PR TITLE
feat(backend): add idempotency middleware and Redis rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/platform-socket.io": "^11.1.24",
     "@nestjs/swagger": "^7.1.0",
     "@nestjs/terminus": "^10.3.0",
+    "@nest-lab/throttler-storage-redis": "^0.4.0",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^10.0.0",
     "@nestjs/websockets": "^11.1.24",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,8 +1,8 @@
-import { Module, MiddlewareConsumer, NestModule } from '@nestjs/common';
+import { Module, MiddlewareConsumer, NestModule, RequestMethod } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { APP_GUARD } from '@nestjs/core';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { WinstonModule } from 'nest-winston';
 import { CacheModule } from '@nestjs/cache-manager';
 import { winstonConfig } from './config/logger.config';
@@ -25,8 +25,10 @@ import databaseConfig from './config/database.config';
 import { validationSchema } from './config/validation.schema';
 import { HttpLoggerMiddleware } from './common/middlewares/http-logger.middleware';
 import { RequestIdMiddleware } from './common/middlewares/request-id.middleware';
+import { IdempotencyMiddleware } from './common/middlewares/idempotency.middleware';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
+import { RedisThrottlerGuard } from './common/guards/redis-throttler.guard';
 
 @Module({
   imports: [
@@ -43,8 +45,44 @@ import { RolesGuard } from './common/guards/roles.guard';
         return config || {};
       },
     }),
-    ThrottlerModule.forRoot([{ name: 'default', ttl: 60_000, limit: 10 }]),
-    CacheModule.register({ isGlobal: true }),
+    // ── Redis-backed distributed rate limiter ──────────────────────────────
+    // Falls back to in-memory storage when REDIS_URL is not set (local dev).
+    ThrottlerModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => {
+        const redisUrl = configService.get<string>('REDIS_URL');
+        const throttlers = [{ name: 'default', ttl: 60_000, limit: 10 }];
+
+        if (redisUrl) {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { ThrottlerStorageRedisService } = require('@nest-lab/throttler-storage-redis');
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const Redis = require('ioredis');
+          return { throttlers, storage: new ThrottlerStorageRedisService(new Redis(redisUrl)) };
+        }
+
+        // No Redis — use the default in-memory store
+        return { throttlers };
+      },
+    }),
+    // ── Cache (idempotency + general) ──────────────────────────────────────
+    // Uses Redis when REDIS_URL is set; falls back to in-memory for local dev.
+    CacheModule.registerAsync({
+      isGlobal: true,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => {
+        const redisUrl = configService.get<string>('REDIS_URL');
+
+        if (redisUrl) {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { redisStore } = require('cache-manager-ioredis-yet');
+          return { store: redisStore, url: redisUrl, ttl: 300_000 };
+        }
+
+        // In-memory fallback
+        return { ttl: 300_000 };
+      },
+    }),
     AuthModule,
     UsersModule,
     ContactModule,
@@ -61,7 +99,9 @@ import { RolesGuard } from './common/guards/roles.guard';
     NotificationsModule,
   ],
   providers: [
-    { provide: APP_GUARD, useClass: ThrottlerGuard },
+    // RedisThrottlerGuard replaces the stock ThrottlerGuard and adds
+    // X-RateLimit-* response headers.
+    { provide: APP_GUARD, useClass: RedisThrottlerGuard },
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
   ],
@@ -73,5 +113,19 @@ export class AppModule implements NestModule {
       .apply(HttpLoggerMiddleware)
       .exclude('health', 'health/live', 'health/ready')
       .forRoutes('*');
+
+    // Idempotency middleware — applied only to state-mutating POST routes
+    // on bookings (and any future mutation-heavy modules).
+    // The middleware runs AFTER JwtAuthGuard has populated req.user, which
+    // happens at the guard layer (before middleware in NestJS execution order).
+    // We therefore apply it as a functional middleware on specific routes so
+    // it executes after authentication.
+    consumer
+      .apply(IdempotencyMiddleware)
+      .forRoutes(
+        { path: 'bookings', method: RequestMethod.POST },
+        { path: 'attendance', method: RequestMethod.POST },
+        { path: 'contact', method: RequestMethod.POST },
+      );
   }
 }

--- a/backend/src/bookings/bookings.controller.ts
+++ b/backend/src/bookings/bookings.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiBearerAuth,
   ApiResponse,
   ApiParam,
+  ApiHeader,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
@@ -42,10 +43,24 @@ Conflict Rules:
 | Capacity Limits | The requested time exceeds the maximum capacity of the workspace |
 | Overlapping Time | For a single capacity workspace, another booking already occupies the time range |`
   })
+  @ApiHeader({
+    name: 'X-Idempotency-Key',
+    description:
+      'Client-generated unique key (UUID v4 recommended) that prevents duplicate bookings ' +
+      'caused by network retries or UI double-submits. ' +
+      'The same key scoped to the same user returns the original response for up to 5 minutes. ' +
+      'Must be 1–128 printable ASCII characters with no whitespace. **Required.**',
+    required: true,
+    schema: { type: 'string', example: '550e8400-e29b-41d4-a716-446655440000' },
+  })
   @ApiResponse({ status: 201, description: 'Booking created successfully' })
   @ApiResponse({
+    status: 200,
+    description: 'Duplicate request — original response replayed (idempotent)',
+  })
+  @ApiResponse({
     status: 409,
-    description: 'Workspace booking conflict detected',
+    description: 'Workspace booking conflict detected OR concurrent duplicate key in-flight',
     schema: {
       type: 'object',
       properties: {
@@ -67,6 +82,18 @@ Conflict Rules:
         }
       }
     }
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'Missing or malformed X-Idempotency-Key header',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 422 },
+        message: { type: 'string', example: 'X-Idempotency-Key header is required for this endpoint' },
+        error: { type: 'string', example: 'Unprocessable Entity' },
+      },
+    },
   })
    create(@Request() req: any, @Body() dto: CreateBookingDto) {
      return this.service.create(req.user.id, dto);

--- a/backend/src/common/guards/redis-throttler.guard.spec.ts
+++ b/backend/src/common/guards/redis-throttler.guard.spec.ts
@@ -1,0 +1,138 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { RedisThrottlerGuard } from './redis-throttler.guard';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: { ip?: string; userId?: string } = {}): ExecutionContext {
+  const req: any = {
+    ip: overrides.ip ?? '127.0.0.1',
+    user: overrides.userId ? { id: overrides.userId } : undefined,
+    headers: {},
+    method: 'POST',
+    url: '/api/v1/auth/login',
+  };
+  const res: any = {
+    _headers: {} as Record<string, string | number>,
+    setHeader: jest.fn((name: string, value: string | number) => {
+      res._headers[name] = value;
+    }),
+  };
+
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => res,
+    }),
+    getClass: () => ({}),
+    getHandler: () => ({}),
+  } as unknown as ExecutionContext;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RedisThrottlerGuard', () => {
+  let guard: RedisThrottlerGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([{ name: 'default', ttl: 60_000, limit: 5 }]),
+      ],
+      providers: [RedisThrottlerGuard],
+    }).compile();
+
+    guard = module.get<RedisThrottlerGuard>(RedisThrottlerGuard);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── Tracker key ─────────────────────────────────────────────────────────
+
+  it('uses user ID as tracker key when user is authenticated', async () => {
+    const ctx = makeContext({ userId: 'user-abc', ip: '10.0.0.1' });
+    const req = ctx.switchToHttp().getRequest();
+    const tracker = await (guard as any).getTracker(req);
+    expect(tracker).toBe('user-abc');
+  });
+
+  it('falls back to IP when user is not authenticated', async () => {
+    const ctx = makeContext({ ip: '192.168.1.1' });
+    const req = ctx.switchToHttp().getRequest();
+    const tracker = await (guard as any).getTracker(req);
+    expect(tracker).toBe('192.168.1.1');
+  });
+
+  it('uses sub field as fallback when id is absent', async () => {
+    const ctx = makeContext();
+    const req = ctx.switchToHttp().getRequest();
+    req.user = { sub: 'sub-xyz' };
+    const tracker = await (guard as any).getTracker(req);
+    expect(tracker).toBe('sub-xyz');
+  });
+
+  // ── Rate-limit headers on throttle exception ─────────────────────────────
+
+  it('sets Retry-After and X-RateLimit-* headers when limit is exceeded', async () => {
+    const ctx = makeContext({ ip: '10.0.0.2' });
+    const res = ctx.switchToHttp().getResponse<any>();
+
+    const throttlerDetail = {
+      limit: 5,
+      ttl: 60_000,
+      key: 'test-key',
+      tracker: '10.0.0.2',
+      totalHits: 6,
+      timeToExpire: 45_000,
+      isBlocked: true,
+      timeToBlockExpire: 45_000,
+    };
+
+    // throwThrottlingException calls super which throws — we just verify headers
+    try {
+      await (guard as any).throwThrottlingException(ctx, throttlerDetail);
+    } catch {
+      // Expected to throw ThrottlerException
+    }
+
+    expect(res.setHeader).toHaveBeenCalledWith('Retry-After', 60);
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', 5);
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', 0);
+  });
+
+  // ── handleRequest sets informational headers ─────────────────────────────
+
+  it('sets X-RateLimit-Limit and X-RateLimit-Window headers on successful request', async () => {
+    const ctx = makeContext({ userId: 'user-1' });
+    const res = ctx.switchToHttp().getResponse<any>();
+
+    // Stub super.handleRequest to avoid hitting the real throttle store
+    jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(guard)), 'handleRequest')
+      .mockResolvedValueOnce(true);
+
+    const throttlerRequest = {
+      context: ctx,
+      limit: 10,
+      ttl: 60_000,
+      throttler: { name: 'default', ttl: 60_000, limit: 10 },
+      blockDuration: 0,
+      key: 'test',
+      tracker: 'user-1',
+      totalHits: 1,
+      timeToExpire: 60_000,
+      isBlocked: false,
+      timeToBlockExpire: 0,
+    };
+
+    await (guard as any).handleRequest(throttlerRequest);
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', 10);
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Window', 60);
+  });
+});

--- a/backend/src/common/guards/redis-throttler.guard.ts
+++ b/backend/src/common/guards/redis-throttler.guard.ts
@@ -1,0 +1,58 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { ThrottlerGuard, ThrottlerLimitDetail, ThrottlerRequest } from '@nestjs/throttler';
+import { Request, Response } from 'express';
+
+/**
+ * Extends the stock ThrottlerGuard to:
+ *  1. Key rate-limit buckets by authenticated user ID (falls back to IP).
+ *  2. Append X-RateLimit-Limit, X-RateLimit-Window, and Retry-After headers.
+ *
+ * Works with both the in-memory store (local dev) and the Redis-backed
+ * ThrottlerStorageRedisService (staging / production).
+ */
+@Injectable()
+export class RedisThrottlerGuard extends ThrottlerGuard {
+  /**
+   * Use the authenticated user's ID as the throttle tracker key so that
+   * rate-limit counters are per-user rather than per-IP. Falls back to IP
+   * for unauthenticated routes (e.g. /auth/login, /auth/resend-otp).
+   */
+  protected async getTracker(req: Request): Promise<string> {
+    const userId: string | undefined =
+      (req as any).user?.id ?? (req as any).user?.sub;
+    return userId ?? req.ip ?? 'anonymous';
+  }
+
+  /**
+   * @nestjs/throttler v6 passes a single ThrottlerRequest object.
+   * We call super first, then attach informational headers on success.
+   */
+  protected async handleRequest(requestProps: ThrottlerRequest): Promise<boolean> {
+    const result = await super.handleRequest(requestProps);
+
+    const res = requestProps.context.switchToHttp().getResponse<Response>();
+    res.setHeader('X-RateLimit-Limit', requestProps.limit);
+    // ttl is in milliseconds — convert to seconds for the header
+    res.setHeader('X-RateLimit-Window', Math.ceil(requestProps.ttl / 1000));
+
+    return result;
+  }
+
+  /**
+   * Called when the rate limit is exceeded (429). Adds Retry-After header
+   * before delegating to the base class which throws ThrottlerException.
+   */
+  protected throwThrottlingException(
+    context: ExecutionContext,
+    throttlerLimitDetail: ThrottlerLimitDetail,
+  ): Promise<void> {
+    const res = context.switchToHttp().getResponse<Response>();
+
+    const retryAfterSeconds = Math.ceil(throttlerLimitDetail.ttl / 1000);
+    res.setHeader('Retry-After', retryAfterSeconds);
+    res.setHeader('X-RateLimit-Limit', throttlerLimitDetail.limit);
+    res.setHeader('X-RateLimit-Remaining', 0);
+
+    return super.throwThrottlingException(context, throttlerLimitDetail);
+  }
+}

--- a/backend/src/common/middlewares/idempotency.middleware.spec.ts
+++ b/backend/src/common/middlewares/idempotency.middleware.spec.ts
@@ -1,0 +1,264 @@
+import { UnprocessableEntityException, UnauthorizedException } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IdempotencyMiddleware } from './idempotency.middleware';
+import { Request, Response } from 'express';
+import * as jwt from 'jsonwebtoken';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = 'test-secret';
+
+function makeToken(userId: string): string {
+  return jwt.sign({ sub: userId, email: 'u@test.com' }, TEST_SECRET, { expiresIn: '1h' });
+}
+
+function makeReq(overrides: Partial<Request> & { userId?: string } = {}): Request {
+  const { userId, ...rest } = overrides;
+  const token = userId ? makeToken(userId) : undefined;
+  return {
+    headers: {
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    ...rest,
+  } as unknown as Request;
+}
+
+function makeRes(): Response & { _status: number; _body: unknown } {
+  const res: any = {
+    _status: 200,
+    _body: undefined,
+    statusCode: 200,
+  };
+  res.status = jest.fn((code: number) => {
+    res._status = code;
+    res.statusCode = code;
+    return res;
+  });
+  res.json = jest.fn((body: unknown) => {
+    res._body = body;
+    return res;
+  });
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('IdempotencyMiddleware', () => {
+  let middleware: IdempotencyMiddleware;
+  let mockCache: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
+
+  beforeEach(async () => {
+    mockCache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IdempotencyMiddleware,
+        { provide: CACHE_MANAGER, useValue: mockCache },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(TEST_SECRET) },
+        },
+      ],
+    }).compile();
+
+    middleware = module.get<IdempotencyMiddleware>(IdempotencyMiddleware);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── Header validation ────────────────────────────────────────────────────
+
+  it('throws 422 when X-Idempotency-Key header is missing', async () => {
+    const req = makeReq({ userId: 'user-1', headers: {} });
+    const res = makeRes();
+    await expect(middleware.use(req, res, jest.fn())).rejects.toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('throws 422 when key contains whitespace', async () => {
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'bad key';
+    const res = makeRes();
+    await expect(middleware.use(req, res, jest.fn())).rejects.toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('throws 422 when key is empty string', async () => {
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = '';
+    const res = makeRes();
+    await expect(middleware.use(req, res, jest.fn())).rejects.toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('throws 422 when key exceeds 128 characters', async () => {
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'a'.repeat(129);
+    const res = makeRes();
+    await expect(middleware.use(req, res, jest.fn())).rejects.toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('throws 401 when no valid Bearer token is present', async () => {
+    const req = makeReq(); // no userId → no token
+    (req.headers as any)['x-idempotency-key'] = 'valid-key';
+    const res = makeRes();
+    await expect(middleware.use(req, res, jest.fn())).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  // ── First request (cache miss) ───────────────────────────────────────────
+
+  it('calls next() and stores in-flight sentinel on first request', async () => {
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'key-abc';
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'idempotency:user-1:key-abc',
+      '__IN_FLIGHT__',
+      expect.any(Number),
+    );
+  });
+
+  it('captures and caches the response when res.json is called with 2xx status', async () => {
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'key-abc';
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware.use(req, res, next);
+
+    // Simulate route handler calling res.json
+    res.json({ id: 'booking-1' });
+
+    // Wait for async cache.set
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'idempotency:user-1:key-abc',
+      { statusCode: 200, body: { id: 'booking-1' } },
+      expect.any(Number),
+    );
+  });
+
+  it('removes in-flight sentinel and does NOT cache on error response', async () => {
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'key-err';
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware.use(req, res, next);
+
+    // Simulate a 409 error response from the route handler
+    res.status(409);
+    res.json({ message: 'conflict' });
+
+    await new Promise((r) => setImmediate(r));
+
+    // Should NOT have cached the error response
+    const setCalls = mockCache.set.mock.calls;
+    const cachedResponseCall = setCalls.find(
+      ([key, val]) => key === 'idempotency:user-1:key-err' && val !== '__IN_FLIGHT__',
+    );
+    expect(cachedResponseCall).toBeUndefined();
+
+    // Should have deleted the in-flight sentinel
+    expect(mockCache.del).toHaveBeenCalledWith('idempotency:user-1:key-err');
+  });
+
+  // ── Duplicate request (cache hit) ────────────────────────────────────────
+
+  it('replays cached response and does NOT call next() on duplicate key', async () => {
+    mockCache.get.mockResolvedValue({ statusCode: 201, body: { id: 'booking-1' } });
+
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'key-abc';
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware.use(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ id: 'booking-1' });
+  });
+
+  it('returns 409 when the same key is in-flight (concurrent duplicate)', async () => {
+    mockCache.get.mockResolvedValue('__IN_FLIGHT__');
+
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'key-abc';
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware.use(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  // ── Cross-user key isolation ─────────────────────────────────────────────
+
+  it('scopes cache key per user so different users with same key are independent', async () => {
+    // user-2 has a cached response for the same idempotency key
+    mockCache.get.mockImplementation(async (key: string) => {
+      if (key === 'idempotency:user-2:shared-key') {
+        return { statusCode: 201, body: { id: 'booking-2' } };
+      }
+      return null;
+    });
+
+    // user-1 should NOT get user-2's cached response
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'shared-key';
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware.use(req, res, next);
+
+    // next() must be called — user-1 has no cached entry for this key
+    expect(next).toHaveBeenCalledTimes(1);
+    // Cache was checked with user-1's scoped key, not user-2's
+    expect(mockCache.get).toHaveBeenCalledWith('idempotency:user-1:shared-key');
+  });
+
+  // ── Different keys create independent records ────────────────────────────
+
+  it('calls next() for a different key even when another key is cached', async () => {
+    mockCache.get.mockImplementation(async (key: string) => {
+      if (key === 'idempotency:user-1:key-old') {
+        return { statusCode: 201, body: { id: 'booking-old' } };
+      }
+      return null;
+    });
+
+    const req = makeReq({ userId: 'user-1' });
+    (req.headers as any)['x-idempotency-key'] = 'key-new';
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/common/middlewares/idempotency.middleware.ts
+++ b/backend/src/common/middlewares/idempotency.middleware.ts
@@ -1,0 +1,129 @@
+import {
+  Injectable,
+  NestMiddleware,
+  UnprocessableEntityException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject } from '@nestjs/common';
+import { Cache } from 'cache-manager';
+import { ConfigService } from '@nestjs/config';
+import * as jwt from 'jsonwebtoken';
+
+/** TTL for cached idempotent responses: 5 minutes in milliseconds */
+const IDEMPOTENCY_TTL_MS = 5 * 60 * 1000;
+
+/** Regex: 1–128 printable ASCII chars (no whitespace) */
+const KEY_PATTERN = /^[\x21-\x7E]{1,128}$/;
+
+/** Shape stored in cache for a completed request */
+interface CachedResponse {
+  statusCode: number;
+  body: unknown;
+}
+
+/** Marker stored while a request is in-flight to detect concurrent duplicates */
+const IN_FLIGHT_SENTINEL = '__IN_FLIGHT__';
+
+@Injectable()
+export class IdempotencyMiddleware implements NestMiddleware {
+  constructor(
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async use(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const rawKey = req.headers['x-idempotency-key'] as string | undefined;
+
+    // Header is required on state-mutating routes where this middleware is applied
+    if (!rawKey) {
+      throw new UnprocessableEntityException(
+        'X-Idempotency-Key header is required for this endpoint',
+      );
+    }
+
+    if (!KEY_PATTERN.test(rawKey)) {
+      throw new UnprocessableEntityException(
+        'X-Idempotency-Key must be 1–128 printable ASCII characters with no whitespace',
+      );
+    }
+
+    // NestJS middleware runs before guards, so req.user is not yet populated.
+    // We decode the JWT ourselves to extract the user ID for cache key scoping.
+    // This is a read-only decode — full verification happens in JwtAuthGuard.
+    const userId = this.extractUserIdFromToken(req);
+    if (!userId) {
+      throw new UnauthorizedException(
+        'Valid Bearer token required to use idempotency key',
+      );
+    }
+
+    const cacheKey = `idempotency:${userId}:${rawKey}`;
+
+    // Check for an existing cached response
+    const cached = await this.cache.get<CachedResponse | typeof IN_FLIGHT_SENTINEL>(cacheKey);
+
+    if (cached === IN_FLIGHT_SENTINEL) {
+      // A concurrent request with the same key is already being processed
+      res.status(409).json({
+        statusCode: 409,
+        message: 'A request with this idempotency key is already being processed',
+        error: 'Conflict',
+      });
+      return;
+    }
+
+    if (cached) {
+      // Replay the stored response — same status, same body
+      res.status(cached.statusCode).json(cached.body);
+      return;
+    }
+
+    // Mark as in-flight before handing off to the route handler
+    await this.cache.set(cacheKey, IN_FLIGHT_SENTINEL, IDEMPOTENCY_TTL_MS);
+
+    // Intercept res.json so we can capture the response body and status
+    const originalJson = res.json.bind(res);
+    res.json = (body: unknown) => {
+      const statusCode = res.statusCode;
+
+      // Only cache successful responses (2xx) — errors should be retryable
+      if (statusCode >= 200 && statusCode < 300) {
+        this.cache
+          .set(cacheKey, { statusCode, body } satisfies CachedResponse, IDEMPOTENCY_TTL_MS)
+          .catch(() => {
+            // Non-fatal: worst case the next retry creates a new record
+          });
+      } else {
+        // Remove the in-flight sentinel so the client can retry on errors
+        this.cache.del(cacheKey).catch(() => {});
+      }
+
+      return originalJson(body);
+    };
+
+    next();
+  }
+
+  /**
+   * Decodes (without verifying signature) the Bearer token to extract `sub`.
+   * Full cryptographic verification is still performed by JwtAuthGuard later
+   * in the request lifecycle. We only need the user ID here for cache scoping.
+   */
+  private extractUserIdFromToken(req: Request): string | null {
+    const authHeader = req.headers['authorization'];
+    if (!authHeader?.startsWith('Bearer ')) return null;
+
+    const token = authHeader.slice(7);
+    try {
+      const secret = this.configService.get<string>('JWT_SECRET') ?? process.env['JWT_SECRET'];
+      if (!secret) return null;
+      const payload = jwt.verify(token, secret) as { sub?: string };
+      return payload.sub ?? null;
+    } catch {
+      // Invalid / expired token — let JwtAuthGuard handle the 401
+      return null;
+    }
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -58,7 +58,18 @@ async function bootstrap() {
       '  "timestamp": "2026-05-27T16:00:00.000Z"\n' +
       '}\n' +
       '```\n\n' +
-      'Error responses retain their original shape (statusCode, message, error, timestamp, path).',
+      'Error responses retain their original shape (statusCode, message, error, timestamp, path).\n\n' +
+      '## Rate Limiting\n\n' +
+      'All endpoints are rate-limited. Exceeded limits return **429 Too Many Requests** with:\n\n' +
+      '| Header | Description |\n' +
+      '|--------|-------------|\n' +
+      '| `X-RateLimit-Limit` | Maximum requests allowed in the window |\n' +
+      '| `X-RateLimit-Window` | Window duration in seconds |\n' +
+      '| `Retry-After` | Seconds until the limit resets |\n\n' +
+      'Stricter limits apply to auth endpoints: `/auth/login` (5/min), `/auth/resend-otp` (3/5min).\n\n' +
+      '## Idempotency\n\n' +
+      'State-mutating endpoints (`POST /bookings`, etc.) require an `X-Idempotency-Key` header.\n' +
+      'Duplicate requests with the same key and user return the original response for 5 minutes.',
     )
     .setVersion('1.0.0')
     .addServer('/api/v1', 'Version 1')

--- a/backend/test/idempotency.e2e-spec.ts
+++ b/backend/test/idempotency.e2e-spec.ts
@@ -1,0 +1,199 @@
+/**
+ * E2E tests for the idempotency key middleware.
+ *
+ * These tests spin up the full NestJS application (with an in-memory cache
+ * store — no Redis required) and exercise POST /api/v1/bookings to verify
+ * that duplicate requests with the same X-Idempotency-Key are safely
+ * deduplicated without creating phantom bookings.
+ *
+ * Run with:
+ *   npm run test:e2e -- --testPathPattern=idempotency
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { getConnection } from 'typeorm';
+import { User, UserRole } from '../src/users/user.entity';
+import { Workspace, WorkspaceType, WorkspaceAvailability } from '../src/workspaces/workspace.entity';
+import { Booking } from '../src/bookings/booking.entity';
+import { StellarService } from '../src/stellar/stellar.service';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
+import { v4 as uuidv4 } from 'uuid';
+
+const mockStellarService = {
+  verifyTransaction: jest.fn().mockResolvedValue({ status: 'SUCCESS' }),
+};
+
+describe('Idempotency Middleware (e2e)', () => {
+  let app: INestApplication;
+  let memberToken: string;
+  let memberUserId: string;
+  let otherMemberToken: string;
+  let workspaceId: string;
+
+  beforeAll(async () => {
+    const testDbUrl = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL;
+    if (!testDbUrl) throw new Error('DATABASE_URL must be set for e2e tests');
+    process.env.DATABASE_URL = testDbUrl;
+    process.env.NODE_ENV = 'test';
+    // Ensure no Redis is used so tests are self-contained
+    delete process.env.REDIS_URL;
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(StellarService)
+      .useValue(mockStellarService)
+      .compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+    const { TransformInterceptor } = await import('../src/common/interceptors/transform.interceptor');
+    const { LoggingInterceptor } = await import('../src/common/interceptors/logging.interceptor');
+    app.useGlobalInterceptors(new LoggingInterceptor(), new TransformInterceptor());
+    await app.init();
+
+    const connection = getConnection();
+    const userRepo = connection.getRepository(User);
+    const workspaceRepo = connection.getRepository(Workspace);
+
+    const member = userRepo.create({
+      email: 'idempotency-member@test.com',
+      passwordHash: await bcrypt.hash('pass', 10),
+      role: UserRole.MEMBER,
+    });
+    await userRepo.save(member);
+    memberUserId = member.id;
+
+    const otherMember = userRepo.create({
+      email: 'idempotency-other@test.com',
+      passwordHash: await bcrypt.hash('pass', 10),
+      role: UserRole.MEMBER,
+    });
+    await userRepo.save(otherMember);
+
+    const workspace = workspaceRepo.create({
+      name: 'Idempotency Test Workspace',
+      type: WorkspaceType.HOT_DESK,
+      capacity: 10,
+      pricePerHour: 50,
+      availability: WorkspaceAvailability.AVAILABLE,
+    });
+    await workspaceRepo.save(workspace);
+    workspaceId = workspace.id;
+
+    const jwtService = module.get(JwtService);
+    memberToken = jwtService.sign({ sub: member.id, email: member.email, role: member.role });
+    otherMemberToken = jwtService.sign({ sub: otherMember.id, email: otherMember.email, role: otherMember.role });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    const conn = getConnection();
+    await conn.dropDatabase();
+    await conn.close();
+  });
+
+  afterEach(async () => {
+    const conn = getConnection();
+    await conn.getRepository(Booking).delete({});
+  });
+
+  // ── Helper ───────────────────────────────────────────────────────────────
+
+  function postBooking(token: string, idempotencyKey: string, body?: object) {
+    const startTime = new Date(Date.now() + 86_400_000).toISOString();
+    const endTime = new Date(Date.now() + 86_400_000 * 2).toISOString();
+
+    return request(app.getHttpServer())
+      .post('/api/v1/bookings')
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Idempotency-Key', idempotencyKey)
+      .send(body ?? { workspaceId, startTime, endTime });
+  }
+
+  // ── Missing / malformed key ──────────────────────────────────────────────
+
+  it('returns 422 when X-Idempotency-Key header is absent', async () => {
+    const startTime = new Date(Date.now() + 86_400_000).toISOString();
+    const endTime = new Date(Date.now() + 86_400_000 * 2).toISOString();
+
+    await request(app.getHttpServer())
+      .post('/api/v1/bookings')
+      .set('Authorization', `Bearer ${memberToken}`)
+      .send({ workspaceId, startTime, endTime })
+      .expect(422);
+  });
+
+  it('returns 422 when X-Idempotency-Key contains whitespace', async () => {
+    await postBooking(memberToken, 'bad key with spaces').expect(422);
+  });
+
+  // ── First request succeeds ───────────────────────────────────────────────
+
+  it('creates a booking on the first request (201)', async () => {
+    const key = uuidv4();
+    const res = await postBooking(memberToken, key).expect(201);
+    expect(res.body.data).toMatchObject({ workspaceId, userId: memberUserId });
+  });
+
+  // ── Duplicate request is deduplicated ────────────────────────────────────
+
+  it('returns the same response on a duplicate request without creating a second booking', async () => {
+    const key = uuidv4();
+
+    const first = await postBooking(memberToken, key).expect(201);
+    const firstBookingId = first.body.data.id;
+
+    // Second request with the same key — must replay the first response
+    const second = await postBooking(memberToken, key);
+    expect(second.status).toBe(201);
+    expect(second.body.data.id).toBe(firstBookingId);
+
+    // Verify only one booking exists in the database
+    const conn = getConnection();
+    const bookings = await conn.getRepository(Booking).find({ where: { userId: memberUserId } });
+    expect(bookings).toHaveLength(1);
+    expect(bookings[0].id).toBe(firstBookingId);
+  });
+
+  // ── Different key creates a new booking ─────────────────────────────────
+
+  it('creates a new booking when a different idempotency key is used', async () => {
+    const startA = new Date(Date.now() + 86_400_000).toISOString();
+    const endA = new Date(Date.now() + 86_400_000 * 2).toISOString();
+    const startB = new Date(Date.now() + 86_400_000 * 3).toISOString();
+    const endB = new Date(Date.now() + 86_400_000 * 4).toISOString();
+
+    const resA = await postBooking(memberToken, uuidv4(), { workspaceId, startTime: startA, endTime: endA }).expect(201);
+    const resB = await postBooking(memberToken, uuidv4(), { workspaceId, startTime: startB, endTime: endB }).expect(201);
+
+    expect(resA.body.data.id).not.toBe(resB.body.data.id);
+
+    const conn = getConnection();
+    const bookings = await conn.getRepository(Booking).find({ where: { userId: memberUserId } });
+    expect(bookings).toHaveLength(2);
+  });
+
+  // ── Cross-user key isolation ─────────────────────────────────────────────
+
+  it('does NOT replay a cached response when a different user sends the same key', async () => {
+    const sharedKey = uuidv4();
+
+    // Member 1 creates a booking
+    const first = await postBooking(memberToken, sharedKey).expect(201);
+    const firstBookingId = first.body.data.id;
+
+    // Member 2 uses the same key — should create a NEW booking, not replay member 1's
+    const startTime = new Date(Date.now() + 86_400_000 * 3).toISOString();
+    const endTime = new Date(Date.now() + 86_400_000 * 4).toISOString();
+
+    const second = await postBooking(otherMemberToken, sharedKey, { workspaceId, startTime, endTime }).expect(201);
+
+    expect(second.body.data.id).not.toBe(firstBookingId);
+  });
+});


### PR DESCRIPTION
Closes #263
Closes #264

## Summary

Two backend hardening features to prevent phantom bookings and ensure
consistent rate limiting across horizontal API replicas.

---

## Feature A — Idempotency Key Middleware

### Problem
Network retries and UI double-submits were creating duplicate bookings
because each HTTP request hit the database independently.

### Solution
IdempotencyMiddleware intercepts POST /bookings (and other mutation
endpoints) before the route handler runs:

1. Validates X-Idempotency-Key (required, 1–128 printable ASCII) → 422 on failure
2. Decodes Bearer JWT to extract userId for cache scoping — middleware
   runs before guards so req.user isn't populated yet; full verification
   still happens in JwtAuthGuard
3. Cache key is idempotency:{userId}:{key} — cross-user reuse is
   structurally impossible
4. Stores __IN_FLIGHT__ sentinel before next() → concurrent duplicate → 409
5. Intercepts res.json to cache 2xx responses for 5 minutes; errors
   clear the sentinel so clients can retry

Request flow:
  Before: Client retry → POST /bookings → DB insert → phantom booking
  After:  Client retry → IdempotencyMiddleware
            HIT  → replay cached 201, no DB touch
            MISS → set IN_FLIGHT → route handler → cache → 201

Endpoints covered: POST /bookings, /attendance, /contact

---

## Feature B — Redis-backed Distributed Rate Limiter

### Problem
In-process ThrottlerGuard had per-instance counters — clients could
bypass limits via load balancer round-robin.

### Solution
RedisThrottlerGuard extends ThrottlerGuard:
- Shared storage via ThrottlerStorageRedisService when REDIS_URL is set;
  falls back to in-memory for local dev (zero config change required)
- getTracker keys by user.id → user.sub → IP (per-user, not per-IP)
- X-RateLimit-Limit, X-RateLimit-Window headers on every response
- Retry-After, X-RateLimit-Remaining: 0 on 429

Existing @Throttle decorators on /auth/login (5/min) and
/auth/resend-otp (3/5min) are unchanged.

---

## Files Changed

- src/common/middlewares/idempotency.middleware.ts — new middleware
- src/common/middlewares/idempotency.middleware.spec.ts — 12 unit tests
- src/common/guards/redis-throttler.guard.ts — new guard
- src/common/guards/redis-throttler.guard.spec.ts — 4 unit tests
- test/idempotency.e2e-spec.ts — 6 E2E tests against POST /bookings
- src/app.module.ts — wire middleware + Redis cache/throttler
- src/bookings/bookings.controller.ts — Swagger X-Idempotency-Key docs
- src/main.ts — Swagger rate-limit + idempotency sections
- package.json — add @nest-lab/throttler-storage-redis
