### PR TITLE
feat(backend): add health check endpoints and TypeORM migration versioning workflow

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,13 @@
     "test:cov": "jest --config jest.config.ts --coverage",
     "test:e2e": "jest --config jest-e2e.config.ts",
     "validate-env": "node scripts/validate-env.js",
-    "seed:bookings": "ts-node scripts/seed-bookings.ts"
+    "seed:bookings": "ts-node scripts/seed-bookings.ts",
+    "migration:run": "ts-node -r tsconfig-paths/register -P tsconfig.json ./node_modules/typeorm/cli.js migration:run -d src/config/typeorm.config.ts",
+    "migration:revert": "ts-node -r tsconfig-paths/register -P tsconfig.json ./node_modules/typeorm/cli.js migration:revert -d src/config/typeorm.config.ts",
+    "migration:generate": "ts-node -r tsconfig-paths/register -P tsconfig.json ./node_modules/typeorm/cli.js migration:generate -d src/config/typeorm.config.ts",
+    "migration:create": "ts-node -r tsconfig-paths/register -P tsconfig.json ./node_modules/typeorm/cli.js migration:create",
+    "migration:show": "ts-node -r tsconfig-paths/register -P tsconfig.json ./node_modules/typeorm/cli.js migration:show -d src/config/typeorm.config.ts",
+    "migration:lint": "node scripts/lint-migrations.js"
   },
   "dependencies": {
     "@nestjs-modules/mailer": "^2.3.6",
@@ -76,6 +82,7 @@
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.0.0"
   }
 }

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -1,0 +1,186 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthCheckService, TypeOrmHealthIndicator, HealthCheckError } from '@nestjs/terminus';
+import { HealthController } from './health.controller';
+import { RedisHealthIndicator } from './indicators/redis.health-indicator';
+import { StellarHealthIndicator } from './indicators/stellar.health-indicator';
+import { SmtpHealthIndicator } from './indicators/smtp.health-indicator';
+import { CloudinaryHealthIndicator } from './indicators/cloudinary.health-indicator';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeHealthService(overrides: Partial<{ check: jest.Mock }> = {}) {
+  return {
+    check: overrides.check ?? jest.fn(),
+  } as unknown as HealthCheckService;
+}
+
+function makeDbIndicator(overrides: Partial<{ pingCheck: jest.Mock }> = {}) {
+  return {
+    pingCheck: overrides.pingCheck ?? jest.fn(),
+  } as unknown as TypeOrmHealthIndicator;
+}
+
+function makeRedisIndicator(overrides: Partial<{ isHealthy: jest.Mock }> = {}) {
+  return { isHealthy: overrides.isHealthy ?? jest.fn() } as unknown as RedisHealthIndicator;
+}
+
+function makeStellarIndicator(overrides: Partial<{ isHealthy: jest.Mock }> = {}) {
+  return { isHealthy: overrides.isHealthy ?? jest.fn() } as unknown as StellarHealthIndicator;
+}
+
+function makeSmtpIndicator(overrides: Partial<{ isHealthy: jest.Mock }> = {}) {
+  return { isHealthy: overrides.isHealthy ?? jest.fn() } as unknown as SmtpHealthIndicator;
+}
+
+function makeCloudinaryIndicator(overrides: Partial<{ isHealthy: jest.Mock }> = {}) {
+  return { isHealthy: overrides.isHealthy ?? jest.fn() } as unknown as CloudinaryHealthIndicator;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HealthController', () => {
+  let controller: HealthController;
+  let healthService: HealthCheckService;
+  let dbIndicator: TypeOrmHealthIndicator;
+  let redisIndicator: RedisHealthIndicator;
+
+  async function buildController(
+    healthServiceOverride?: Partial<{ check: jest.Mock }>,
+  ) {
+    healthService = makeHealthService(healthServiceOverride);
+    dbIndicator = makeDbIndicator();
+    redisIndicator = makeRedisIndicator();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        { provide: HealthCheckService, useValue: healthService },
+        { provide: TypeOrmHealthIndicator, useValue: dbIndicator },
+        { provide: RedisHealthIndicator, useValue: redisIndicator },
+        { provide: StellarHealthIndicator, useValue: makeStellarIndicator() },
+        { provide: SmtpHealthIndicator, useValue: makeSmtpIndicator() },
+        { provide: CloudinaryHealthIndicator, useValue: makeCloudinaryIndicator() },
+      ],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  }
+
+  // ── liveness ──────────────────────────────────────────────────────────────
+
+  describe('GET /health/live', () => {
+    it('returns status ok with process metadata', async () => {
+      await buildController();
+      const result = controller.liveness();
+
+      expect(result.status).toBe('ok');
+      expect(typeof result.uptime).toBe('number');
+      expect(typeof result.pid).toBe('number');
+      expect(result.memory).toHaveProperty('heapUsedMb');
+      expect(result.memory).toHaveProperty('rssMb');
+    });
+
+    it('never calls any health indicator', async () => {
+      await buildController();
+      controller.liveness();
+
+      expect((healthService.check as jest.Mock)).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── readiness ─────────────────────────────────────────────────────────────
+
+  describe('GET /health/ready', () => {
+    it('returns ok result when all checks pass', async () => {
+      const okResult = {
+        status: 'ok',
+        info: { database: { status: 'up' }, redis: { status: 'up' } },
+        error: {},
+        details: { database: { status: 'up' }, redis: { status: 'up' } },
+      };
+
+      await buildController({ check: jest.fn().mockResolvedValue(okResult) });
+      const result = await controller.readiness();
+
+      expect(result.status).toBe('ok');
+      expect((healthService.check as jest.Mock)).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates error when database is down', async () => {
+      const dbDownError = new HealthCheckError('DB down', {
+        status: 'error',
+        info: {},
+        error: { database: { status: 'down' } },
+        details: { database: { status: 'down' } },
+      });
+
+      await buildController({ check: jest.fn().mockRejectedValue(dbDownError) });
+
+      await expect(controller.readiness()).rejects.toThrow(HealthCheckError);
+    });
+
+    it('returns degraded when redis is down but db is up', async () => {
+      const degradedResult = {
+        status: 'error',
+        info: { database: { status: 'up' } },
+        error: { redis: { status: 'down' } },
+        details: { database: { status: 'up' }, redis: { status: 'down' } },
+      };
+
+      // Terminus throws HealthCheckError for non-ok status
+      const degradedError = new HealthCheckError('Redis down', degradedResult);
+      await buildController({ check: jest.fn().mockRejectedValue(degradedError) });
+
+      await expect(controller.readiness()).rejects.toThrow(HealthCheckError);
+    });
+  });
+
+  // ── deep ──────────────────────────────────────────────────────────────────
+
+  describe('GET /health/deep', () => {
+    it('calls all five indicators', async () => {
+      const okResult = {
+        status: 'ok',
+        info: {},
+        error: {},
+        details: {},
+      };
+
+      await buildController({ check: jest.fn().mockResolvedValue(okResult) });
+      await controller.deep();
+
+      // health.check is called with an array of 5 factory functions
+      const checkCall = (healthService.check as jest.Mock).mock.calls[0][0] as (() => unknown)[];
+      expect(checkCall).toHaveLength(5);
+    });
+
+    it('returns degraded when one optional dependency is down', async () => {
+      const degradedResult = {
+        status: 'error',
+        info: {
+          database: { status: 'up' },
+          redis: { status: 'up' },
+          smtp: { status: 'up' },
+          cloudinary: { status: 'up' },
+        },
+        error: { stellar_rpc: { status: 'down', error: 'timeout' } },
+        details: {
+          database: { status: 'up' },
+          redis: { status: 'up' },
+          stellar_rpc: { status: 'down' },
+          smtp: { status: 'up' },
+          cloudinary: { status: 'up' },
+        },
+      };
+
+      const degradedError = new HealthCheckError('Stellar down', degradedResult);
+      await buildController({ check: jest.fn().mockRejectedValue(degradedError) });
+
+      await expect(controller.deep()).rejects.toThrow(HealthCheckError);
+    });
+  });
+});

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,52 +1,186 @@
 import { Controller, Get } from '@nestjs/common';
-import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import {
+  HealthCheck,
+  HealthCheckService,
+  TypeOrmHealthIndicator,
+  HealthCheckResult,
+} from '@nestjs/terminus';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiOkResponse,
+  ApiServiceUnavailableResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
 import { Public } from '../common/decorators/public.decorator';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/user.entity';
+import { RedisHealthIndicator } from './indicators/redis.health-indicator';
+import { StellarHealthIndicator } from './indicators/stellar.health-indicator';
+import { SmtpHealthIndicator } from './indicators/smtp.health-indicator';
+import { CloudinaryHealthIndicator } from './indicators/cloudinary.health-indicator';
 
+/**
+ * Health check endpoints for Kubernetes probes and monitoring.
+ *
+ * Probe configuration summary:
+ *
+ *   GET /api/v1/health/live   → k8s livenessProbe  (always 200 while process is alive)
+ *   GET /api/v1/health/ready  → k8s readinessProbe (503 when DB or Redis are unreachable)
+ *   GET /api/v1/health/deep   → admin-only full dependency graph
+ *   GET /api/v1/health        → alias for /ready (backward-compat)
+ */
 @ApiTags('Health')
 @Controller('health')
+@SkipThrottle() // health probes must never be rate-limited
 export class HealthController {
   constructor(
-    private health: HealthCheckService,
-    private db: TypeOrmHealthIndicator,
+    private readonly health: HealthCheckService,
+    private readonly db: TypeOrmHealthIndicator,
+    private readonly redis: RedisHealthIndicator,
+    private readonly stellar: StellarHealthIndicator,
+    private readonly smtp: SmtpHealthIndicator,
+    private readonly cloudinaryIndicator: CloudinaryHealthIndicator,
   ) {}
 
-  @Get()
+  // ---------------------------------------------------------------------------
+  // GET /health/live — Kubernetes livenessProbe
+  // ---------------------------------------------------------------------------
+  /**
+   * Liveness probe.
+   *
+   * Returns HTTP 200 as long as the Node.js process is running.
+   * **Never** checks external dependencies — a slow DB must not restart the pod.
+   *
+   * Kubernetes liveness probe YAML:
+   * ```yaml
+   * livenessProbe:
+   *   httpGet:
+   *     path: /api/v1/health/live
+   *     port: 3001
+   *   initialDelaySeconds: 10
+   *   periodSeconds: 15
+   *   failureThreshold: 3
+   *   timeoutSeconds: 2
+   * ```
+   */
+  @Get('live')
   @Public()
-  @HealthCheck()
-  @ApiOperation({ summary: 'Basic health check' })
-  async check() {
-    const result = await this.health.check([() => this.db.pingCheck('database')]);
+  @ApiOperation({
+    summary: 'Liveness probe',
+    description:
+      'Returns 200 while the process is alive. Never fails due to external dependencies. ' +
+      'Use as Kubernetes livenessProbe.',
+  })
+  @ApiOkResponse({ description: 'Process is alive' })
+  liveness() {
+    const mem = process.memoryUsage();
     return {
-      status: result.status === 'ok' ? 'ok' : 'error',
+      status: 'ok',
       timestamp: new Date().toISOString(),
-      uptime: process.uptime(),
-      database: result.details?.database?.status === 'up' ? 'connected' : 'disconnected',
+      uptime: Math.floor(process.uptime()),
+      pid: process.pid,
+      memory: {
+        heapUsedMb: Math.round(mem.heapUsed / 1024 / 1024),
+        heapTotalMb: Math.round(mem.heapTotal / 1024 / 1024),
+        rssMb: Math.round(mem.rss / 1024 / 1024),
+      },
     };
   }
 
-  @Get('detailed')
+  // ---------------------------------------------------------------------------
+  // GET /health/ready — Kubernetes readinessProbe
+  // ---------------------------------------------------------------------------
+  /**
+   * Readiness probe.
+   *
+   * Returns HTTP 200 when the app can serve traffic (DB + Redis reachable).
+   * Returns HTTP 503 when either dependency is down — the load balancer will
+   * stop routing requests to this pod until it recovers.
+   *
+   * Each check has a 3-second timeout to keep total response time under 500 ms
+   * in the happy path.
+   *
+   * Kubernetes readiness probe YAML:
+   * ```yaml
+   * readinessProbe:
+   *   httpGet:
+   *     path: /api/v1/health/ready
+   *     port: 3001
+   *   initialDelaySeconds: 15
+   *   periodSeconds: 10
+   *   failureThreshold: 3
+   *   successThreshold: 1
+   *   timeoutSeconds: 5
+   * ```
+   */
+  @Get('ready')
+  @Public()
+  @HealthCheck()
+  @ApiOperation({
+    summary: 'Readiness probe',
+    description:
+      'Returns 200 when DB and Redis are reachable. Returns 503 otherwise. ' +
+      'Use as Kubernetes readinessProbe.',
+  })
+  @ApiOkResponse({ description: 'Application is ready to serve traffic' })
+  @ApiServiceUnavailableResponse({ description: 'One or more critical dependencies are down' })
+  async readiness(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.db.pingCheck('database', { timeout: 3000 }),
+      () => this.redis.isHealthy('redis'),
+    ]);
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /health — backward-compatible alias for /ready
+  // ---------------------------------------------------------------------------
+  @Get()
+  @Public()
+  @HealthCheck()
+  @ApiOperation({
+    summary: 'Health check (alias for /ready)',
+    description: 'Backward-compatible alias. Prefer /health/ready for new integrations.',
+  })
+  @ApiOkResponse({ description: 'Application is healthy' })
+  @ApiServiceUnavailableResponse({ description: 'One or more critical dependencies are down' })
+  async check(): Promise<HealthCheckResult> {
+    return this.readiness();
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /health/deep — admin-only full dependency graph
+  // ---------------------------------------------------------------------------
+  /**
+   * Deep health check — admin only.
+   *
+   * Checks all external dependencies: PostgreSQL, Redis, Stellar RPC, SMTP,
+   * and Cloudinary. Optional services (Redis, SMTP, Cloudinary) report
+   * `skipped` when not configured rather than failing.
+   *
+   * This endpoint is protected by JWT + ADMIN role and is intended for
+   * monitoring dashboards and on-call runbooks, not k8s probes.
+   */
+  @Get('deep')
   @Roles(UserRole.ADMIN)
   @HealthCheck()
-  @ApiOperation({ summary: 'Detailed health check (admin only)' })
-  async detailed() {
-    const result = await this.health.check([() => this.db.pingCheck('database')]);
-    const mem = process.memoryUsage();
-    return {
-      status: result.status,
-      timestamp: new Date().toISOString(),
-      uptime: process.uptime(),
-      database: result.details?.database ?? {},
-      memory: {
-        heapUsed: mem.heapUsed,
-        heapTotal: mem.heapTotal,
-        rss: mem.rss,
-        external: mem.external,
-      },
-      version: process.env.npm_package_version ?? '0.1.0',
-      nodeVersion: process.version,
-    };
+  @ApiBearerAuth('bearer')
+  @ApiOperation({
+    summary: 'Deep health check (admin only)',
+    description:
+      'Checks all external dependencies. Requires ADMIN role. ' +
+      'Not suitable for k8s probes — use /live and /ready instead.',
+  })
+  @ApiOkResponse({ description: 'All dependencies healthy' })
+  @ApiServiceUnavailableResponse({ description: 'One or more dependencies are degraded or down' })
+  async deep(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.db.pingCheck('database', { timeout: 3000 }),
+      () => this.redis.isHealthy('redis'),
+      () => this.stellar.isHealthy('stellar_rpc'),
+      () => this.smtp.isHealthy('smtp'),
+      () => this.cloudinaryIndicator.isHealthy('cloudinary'),
+    ]);
   }
 }

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -1,9 +1,27 @@
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
+import { ConfigModule } from '@nestjs/config';
 import { HealthController } from './health.controller';
+import { RedisHealthIndicator } from './indicators/redis.health-indicator';
+import { StellarHealthIndicator } from './indicators/stellar.health-indicator';
+import { SmtpHealthIndicator } from './indicators/smtp.health-indicator';
+import { CloudinaryHealthIndicator } from './indicators/cloudinary.health-indicator';
 
 @Module({
-  imports: [TerminusModule],
+  imports: [
+    TerminusModule.forRoot({
+      // Terminus will return HTTP 503 on failed checks by default.
+      // errorLogStyle: 'minimal' keeps logs clean in production.
+      errorLogStyle: 'minimal',
+    }),
+    ConfigModule,
+  ],
   controllers: [HealthController],
+  providers: [
+    RedisHealthIndicator,
+    StellarHealthIndicator,
+    SmtpHealthIndicator,
+    CloudinaryHealthIndicator,
+  ],
 })
 export class HealthModule {}

--- a/backend/src/health/indicators/cloudinary.health-indicator.ts
+++ b/backend/src/health/indicators/cloudinary.health-indicator.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import { v2 as cloudinary } from 'cloudinary';
+
+@Injectable()
+export class CloudinaryHealthIndicator extends HealthIndicator {
+  constructor(private readonly configService: ConfigService) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const cloudName = this.configService.get<string>('CLOUDINARY_CLOUD_NAME');
+    const apiKey = this.configService.get<string>('CLOUDINARY_API_KEY');
+    const apiSecret = this.configService.get<string>('CLOUDINARY_API_SECRET');
+
+    if (!cloudName || !apiKey || !apiSecret) {
+      return this.getStatus(key, true, {
+        status: 'skipped',
+        reason: 'Cloudinary credentials not configured',
+      });
+    }
+
+    cloudinary.config({ cloud_name: cloudName, api_key: apiKey, api_secret: apiSecret });
+
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Cloudinary ping timed out after 5s')), 5000),
+    );
+
+    try {
+      // ping() calls GET /ping on the Cloudinary API — lightweight, no quota cost
+      const result = await Promise.race([
+        cloudinary.api.ping() as Promise<{ status: string }>,
+        timeoutPromise,
+      ]);
+
+      const isUp = result?.status === 'ok';
+
+      if (!isUp) {
+        throw new HealthCheckError(
+          `Cloudinary ping returned unexpected status: ${result?.status}`,
+          this.getStatus(key, false, { status: 'down', response: result }),
+        );
+      }
+
+      return this.getStatus(key, true, { status: 'up', cloudName });
+    } catch (err) {
+      if (err instanceof HealthCheckError) throw err;
+
+      throw new HealthCheckError(
+        `Cloudinary health check failed: ${(err as Error).message}`,
+        this.getStatus(key, false, {
+          status: 'down',
+          error: (err as Error).message,
+          cloudName,
+        }),
+      );
+    }
+  }
+}

--- a/backend/src/health/indicators/redis.health-indicator.ts
+++ b/backend/src/health/indicators/redis.health-indicator.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+@Injectable()
+export class RedisHealthIndicator extends HealthIndicator {
+  constructor(private readonly configService: ConfigService) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const redisUrl = this.configService.get<string>('REDIS_URL');
+
+    if (!redisUrl) {
+      // Redis is optional — report as skipped rather than failing
+      return this.getStatus(key, true, { status: 'skipped', reason: 'REDIS_URL not configured' });
+    }
+
+    const client = new Redis(redisUrl, {
+      connectTimeout: 3000,
+      commandTimeout: 3000,
+      lazyConnect: true,
+      maxRetriesPerRequest: 0,
+      enableOfflineQueue: false,
+    });
+
+    try {
+      await client.connect();
+      const pong = await client.ping();
+      const isUp = pong === 'PONG';
+      await client.quit();
+
+      if (!isUp) {
+        throw new HealthCheckError(
+          'Redis ping did not return PONG',
+          this.getStatus(key, false, { status: 'down', response: pong }),
+        );
+      }
+
+      return this.getStatus(key, true, { status: 'up' });
+    } catch (err) {
+      client.disconnect();
+      if (err instanceof HealthCheckError) throw err;
+
+      throw new HealthCheckError(
+        `Redis health check failed: ${(err as Error).message}`,
+        this.getStatus(key, false, {
+          status: 'down',
+          error: (err as Error).message,
+        }),
+      );
+    }
+  }
+}

--- a/backend/src/health/indicators/smtp.health-indicator.ts
+++ b/backend/src/health/indicators/smtp.health-indicator.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+
+@Injectable()
+export class SmtpHealthIndicator extends HealthIndicator {
+  constructor(private readonly configService: ConfigService) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const host = this.configService.get<string>('SMTP_HOST');
+    const port = this.configService.get<number>('SMTP_PORT', 587);
+    const user = this.configService.get<string>('SMTP_USER');
+    const pass = this.configService.get<string>('SMTP_PASSWORD');
+
+    if (!host || !user || !pass) {
+      return this.getStatus(key, true, {
+        status: 'skipped',
+        reason: 'SMTP credentials not configured',
+      });
+    }
+
+    const transporter = nodemailer.createTransport({
+      host,
+      port,
+      secure: port === 465,
+      auth: { user, pass },
+      connectionTimeout: 5000,
+      greetingTimeout: 5000,
+      socketTimeout: 5000,
+    });
+
+    try {
+      await transporter.verify();
+      return this.getStatus(key, true, { status: 'up', host, port });
+    } catch (err) {
+      throw new HealthCheckError(
+        `SMTP health check failed: ${(err as Error).message}`,
+        this.getStatus(key, false, {
+          status: 'down',
+          host,
+          port,
+          error: (err as Error).message,
+        }),
+      );
+    } finally {
+      transporter.close();
+    }
+  }
+}

--- a/backend/src/health/indicators/stellar.health-indicator.ts
+++ b/backend/src/health/indicators/stellar.health-indicator.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+
+const STELLAR_RPC_URLS: Record<string, string> = {
+  mainnet: 'https://soroban-rpc.mainnet.stellar.org',
+  testnet: 'https://soroban-testnet.stellar.org',
+};
+
+@Injectable()
+export class StellarHealthIndicator extends HealthIndicator {
+  private readonly rpcUrl: string;
+
+  constructor(private readonly configService: ConfigService) {
+    super();
+    const network = this.configService.get<string>('STELLAR_NETWORK', 'testnet');
+    this.rpcUrl = STELLAR_RPC_URLS[network] ?? STELLAR_RPC_URLS['testnet'];
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    try {
+      const response = await fetch(this.rpcUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getHealth', params: [] }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeout);
+
+      if (!response.ok) {
+        throw new HealthCheckError(
+          `Stellar RPC returned HTTP ${response.status}`,
+          this.getStatus(key, false, {
+            status: 'down',
+            httpStatus: response.status,
+            url: this.rpcUrl,
+          }),
+        );
+      }
+
+      const body = (await response.json()) as { result?: { status?: string } };
+      const rpcStatus = body?.result?.status;
+
+      return this.getStatus(key, true, {
+        status: 'up',
+        rpcStatus: rpcStatus ?? 'unknown',
+        url: this.rpcUrl,
+      });
+    } catch (err) {
+      clearTimeout(timeout);
+      if (err instanceof HealthCheckError) throw err;
+
+      throw new HealthCheckError(
+        `Stellar RPC health check failed: ${(err as Error).message}`,
+        this.getStatus(key, false, {
+          status: 'down',
+          error: (err as Error).message,
+          url: this.rpcUrl,
+        }),
+      );
+    }
+  }
+}

--- a/backend/test/health.e2e-spec.ts
+++ b/backend/test/health.e2e-spec.ts
@@ -1,0 +1,218 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
+import { TerminusModule, HealthCheckService, TypeOrmHealthIndicator, HealthCheckError } from '@nestjs/terminus';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import request from 'supertest';
+import { HealthController } from '../src/health/health.controller';
+import { RedisHealthIndicator } from '../src/health/indicators/redis.health-indicator';
+import { StellarHealthIndicator } from '../src/health/indicators/stellar.health-indicator';
+import { SmtpHealthIndicator } from '../src/health/indicators/smtp.health-indicator';
+import { CloudinaryHealthIndicator } from '../src/health/indicators/cloudinary.health-indicator';
+import { JwtAuthGuard } from '../src/auth/jwt-auth.guard';
+import { JwtStrategy } from '../src/auth/jwt.strategy';
+import { TransformInterceptor } from '../src/common/interceptors/transform.interceptor';
+import { LoggingInterceptor } from '../src/common/interceptors/logging.interceptor';
+
+const JWT_SECRET = 'hubassist-secret';
+
+// ---------------------------------------------------------------------------
+// Shared mock factories
+// ---------------------------------------------------------------------------
+
+const makeDbIndicator = (healthy = true) => ({
+  pingCheck: jest.fn().mockImplementation(async (key: string) => {
+    if (!healthy) {
+      throw new HealthCheckError('DB down', { [key]: { status: 'down' } });
+    }
+    return { [key]: { status: 'up' } };
+  }),
+});
+
+const makeRedisIndicator = (healthy = true) => ({
+  isHealthy: jest.fn().mockImplementation(async (key: string) => {
+    if (!healthy) {
+      throw new HealthCheckError('Redis down', { [key]: { status: 'down' } });
+    }
+    return { [key]: { status: 'up' } };
+  }),
+});
+
+const makeOptionalIndicator = (key: string, healthy = true) => ({
+  isHealthy: jest.fn().mockImplementation(async () => {
+    if (!healthy) {
+      throw new HealthCheckError(`${key} down`, { [key]: { status: 'down' } });
+    }
+    return { [key]: { status: 'up' } };
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('Health (e2e)', () => {
+  let app: INestApplication;
+  let jwtService: JwtService;
+
+  // Build a fresh app for each describe block so we can swap indicator mocks
+  async function buildApp(options: {
+    dbHealthy?: boolean;
+    redisHealthy?: boolean;
+    stellarHealthy?: boolean;
+    smtpHealthy?: boolean;
+    cloudinaryHealthy?: boolean;
+  } = {}) {
+    const {
+      dbHealthy = true,
+      redisHealthy = true,
+      stellarHealthy = true,
+      smtpHealthy = true,
+      cloudinaryHealthy = true,
+    } = options;
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        TerminusModule,
+        PassportModule,
+        JwtModule.register({ secret: JWT_SECRET, signOptions: { expiresIn: '1h' } }),
+      ],
+      controllers: [HealthController],
+      providers: [
+        JwtStrategy,
+        { provide: APP_GUARD, useClass: JwtAuthGuard },
+        { provide: TypeOrmHealthIndicator, useValue: makeDbIndicator(dbHealthy) },
+        { provide: RedisHealthIndicator, useValue: makeRedisIndicator(redisHealthy) },
+        { provide: StellarHealthIndicator, useValue: makeOptionalIndicator('stellar_rpc', stellarHealthy) },
+        { provide: SmtpHealthIndicator, useValue: makeOptionalIndicator('smtp', smtpHealthy) },
+        { provide: CloudinaryHealthIndicator, useValue: makeOptionalIndicator('cloudinary', cloudinaryHealthy) },
+      ],
+    }).compile();
+
+    const nestApp = module.createNestApplication();
+    nestApp.setGlobalPrefix('api');
+    nestApp.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+    nestApp.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    nestApp.useGlobalInterceptors(new LoggingInterceptor(), new TransformInterceptor());
+    await nestApp.init();
+
+    jwtService = module.get(JwtService);
+    return nestApp;
+  }
+
+  const adminToken = () =>
+    jwtService.sign({ sub: 'admin-uuid', email: 'admin@test.com', role: 'admin' });
+
+  afterEach(async () => {
+    if (app) await app.close();
+  });
+
+  // ── GET /health/live ───────────────────────────────────────────────────────
+
+  describe('GET /api/v1/health/live', () => {
+    it('200 – always returns ok regardless of dependency state', async () => {
+      app = await buildApp({ dbHealthy: false, redisHealthy: false });
+
+      return request(app.getHttpServer())
+        .get('/api/v1/health/live')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.status).toBe('ok');
+          expect(typeof res.body.uptime).toBe('number');
+          expect(res.body.memory).toBeDefined();
+        });
+    });
+
+    it('200 – no auth required', async () => {
+      app = await buildApp();
+      return request(app.getHttpServer()).get('/api/v1/health/live').expect(200);
+    });
+  });
+
+  // ── GET /health/ready ──────────────────────────────────────────────────────
+
+  describe('GET /api/v1/health/ready', () => {
+    it('200 – returns ok when DB and Redis are healthy', async () => {
+      app = await buildApp({ dbHealthy: true, redisHealthy: true });
+
+      return request(app.getHttpServer())
+        .get('/api/v1/health/ready')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.status).toBe('ok');
+        });
+    });
+
+    it('503 – returns service unavailable when database connection is down', async () => {
+      app = await buildApp({ dbHealthy: false });
+
+      return request(app.getHttpServer())
+        .get('/api/v1/health/ready')
+        .expect(503)
+        .expect((res) => {
+          expect(res.body.status).toBe('error');
+          expect(res.body.error?.database ?? res.body.details?.database).toBeDefined();
+        });
+    });
+
+    it('503 – returns service unavailable when Redis is down', async () => {
+      app = await buildApp({ dbHealthy: true, redisHealthy: false });
+
+      return request(app.getHttpServer())
+        .get('/api/v1/health/ready')
+        .expect(503)
+        .expect((res) => {
+          expect(res.body.status).toBe('error');
+        });
+    });
+
+    it('200 – no auth required', async () => {
+      app = await buildApp();
+      return request(app.getHttpServer()).get('/api/v1/health/ready').expect(200);
+    });
+  });
+
+  // ── GET /health ────────────────────────────────────────────────────────────
+
+  describe('GET /api/v1/health', () => {
+    it('200 – alias for /ready when healthy', async () => {
+      app = await buildApp();
+      return request(app.getHttpServer()).get('/api/v1/health').expect(200);
+    });
+  });
+
+  // ── GET /health/deep ───────────────────────────────────────────────────────
+
+  describe('GET /api/v1/health/deep', () => {
+    it('401 – rejects unauthenticated requests', async () => {
+      app = await buildApp();
+      return request(app.getHttpServer()).get('/api/v1/health/deep').expect(401);
+    });
+
+    it('200 – returns ok for admin when all dependencies are healthy', async () => {
+      app = await buildApp();
+
+      return request(app.getHttpServer())
+        .get('/api/v1/health/deep')
+        .set('Authorization', `Bearer ${adminToken()}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.status).toBe('ok');
+          expect(res.body.details?.database).toBeDefined();
+        });
+    });
+
+    it('503 – returns degraded when one optional dependency is down', async () => {
+      app = await buildApp({ stellarHealthy: false });
+
+      return request(app.getHttpServer())
+        .get('/api/v1/health/deep')
+        .set('Authorization', `Bearer ${adminToken()}`)
+        .expect(503)
+        .expect((res) => {
+          expect(res.body.status).toBe('error');
+        });
+    });
+  });
+});


### PR DESCRIPTION

closes #281 
closes #282 

- Implements /health/live, /health/ready, /health/deep using @nestjs/terminus
- Custom indicators for PostgreSQL, Redis, Stellar RPC, SMTP, and Cloudinary
- Liveness probe never fails on external deps; readiness gates traffic via DB + Redis
- Deep check is admin-only with full dependency graph diagnostics
- Replaces synchronize:true with TypeORM migration workflow for all non-test envs
- Adds migration:run/revert/generate/create/show/lint npm scripts
- Migration lint enforces down() implementation and human-readable filenames in CI
- Docker Compose migrate service runs before backend on every deploy
- CI runs migration:lint in lint job and migration:run before e2e suite
- Adds docs/migrations.md with authoring guide, expand/contract pattern, and k8s probe YAML
