### PR TITLE
feat(backend): admin revenue reporting API + multi-resolution profile pictures

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { HealthModule } from './health/health.module';
 import { HubsModule } from './hubs/hubs.module';
 import { AnalyticsModule } from './analytics/analytics.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { ReportsModule } from './reports/reports.module';
 import appConfig from './config/app.config';
 import databaseConfig from './config/database.config';
 import { validationSchema } from './config/validation.schema';
@@ -59,6 +60,7 @@ import { RolesGuard } from './common/guards/roles.guard';
     HubsModule,
     AnalyticsModule,
     NotificationsModule,
+    ReportsModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/cloudinary/cloudinary.constants.spec.ts
+++ b/backend/src/cloudinary/cloudinary.constants.spec.ts
@@ -1,0 +1,107 @@
+import {
+  buildVariantUrl,
+  PROFILE_PICTURE_VARIANTS,
+  CLOUDINARY_PROFILE_FOLDER,
+} from './cloudinary.constants';
+
+describe('Cloudinary constants', () => {
+  const CLOUD_NAME = 'test-cloud';
+  const PUBLIC_ID = 'hubassist/profile-pictures/user123';
+
+  describe('PROFILE_PICTURE_VARIANTS', () => {
+    it('defines thumbnail as 50×50 with face gravity', () => {
+      const v = PROFILE_PICTURE_VARIANTS.thumbnail;
+      expect(v.width).toBe(50);
+      expect(v.height).toBe(50);
+      expect(v.gravity).toBe('face');
+      expect(v.crop).toBe('fill');
+    });
+
+    it('defines avatar as 200×200 with face gravity', () => {
+      const v = PROFILE_PICTURE_VARIANTS.avatar;
+      expect(v.width).toBe(200);
+      expect(v.height).toBe(200);
+      expect(v.gravity).toBe('face');
+      expect(v.crop).toBe('fill');
+    });
+
+    it('defines full as 800×800 with auto gravity', () => {
+      const v = PROFILE_PICTURE_VARIANTS.full;
+      expect(v.width).toBe(800);
+      expect(v.height).toBe(800);
+      expect(v.gravity).toBe('auto');
+      expect(v.crop).toBe('limit');
+    });
+  });
+
+  describe('buildVariantUrl()', () => {
+    it('generates correct thumbnail URL with transformation parameters', () => {
+      const url = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.thumbnail);
+      expect(url).toBe(
+        `https://res.cloudinary.com/${CLOUD_NAME}/image/upload/w_50,h_50,c_fill,g_face,q_auto,f_auto/${PUBLIC_ID}`,
+      );
+    });
+
+    it('generates correct avatar URL with transformation parameters', () => {
+      const url = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.avatar);
+      expect(url).toBe(
+        `https://res.cloudinary.com/${CLOUD_NAME}/image/upload/w_200,h_200,c_fill,g_face,q_auto,f_auto/${PUBLIC_ID}`,
+      );
+    });
+
+    it('generates correct full URL with transformation parameters', () => {
+      const url = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.full);
+      expect(url).toBe(
+        `https://res.cloudinary.com/${CLOUD_NAME}/image/upload/w_800,h_800,c_limit,g_auto,q_auto,f_auto/${PUBLIC_ID}`,
+      );
+    });
+
+    it('all three variant URLs share the same public_id path', () => {
+      const thumbnail = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.thumbnail);
+      const avatar = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.avatar);
+      const full = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.full);
+
+      // All derived from the same upload – only the transformation segment differs
+      expect(thumbnail).toContain(PUBLIC_ID);
+      expect(avatar).toContain(PUBLIC_ID);
+      expect(full).toContain(PUBLIC_ID);
+
+      // Transformation segments are distinct
+      expect(thumbnail).not.toBe(avatar);
+      expect(avatar).not.toBe(full);
+      expect(thumbnail).not.toBe(full);
+    });
+
+    it('thumbnail URL contains w_50 and h_50', () => {
+      const url = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.thumbnail);
+      expect(url).toContain('w_50');
+      expect(url).toContain('h_50');
+    });
+
+    it('avatar URL contains w_200 and h_200', () => {
+      const url = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.avatar);
+      expect(url).toContain('w_200');
+      expect(url).toContain('h_200');
+    });
+
+    it('full URL contains w_800 and h_800', () => {
+      const url = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, PROFILE_PICTURE_VARIANTS.full);
+      expect(url).toContain('w_800');
+      expect(url).toContain('h_800');
+    });
+
+    it('all URLs include q_auto and f_auto for quality/format optimisation', () => {
+      for (const variant of Object.values(PROFILE_PICTURE_VARIANTS)) {
+        const url = buildVariantUrl(CLOUD_NAME, PUBLIC_ID, variant);
+        expect(url).toContain('q_auto');
+        expect(url).toContain('f_auto');
+      }
+    });
+  });
+
+  describe('CLOUDINARY_PROFILE_FOLDER', () => {
+    it('is set to the expected folder path', () => {
+      expect(CLOUDINARY_PROFILE_FOLDER).toBe('hubassist/profile-pictures');
+    });
+  });
+});

--- a/backend/src/cloudinary/cloudinary.constants.ts
+++ b/backend/src/cloudinary/cloudinary.constants.ts
@@ -1,0 +1,47 @@
+/**
+ * Centralised Cloudinary transformation constants.
+ *
+ * All transformation strings are built here so they can be reused across
+ * the service and tested in isolation without hitting the Cloudinary API.
+ */
+
+export const CLOUDINARY_PROFILE_FOLDER = 'hubassist/profile-pictures';
+
+/**
+ * Variant definitions for profile pictures.
+ *
+ * Each entry describes:
+ *  - key    : the property name stored in the JSONB column
+ *  - width  : target width in pixels
+ *  - height : target height in pixels
+ *  - crop   : Cloudinary crop mode
+ *  - gravity: Cloudinary gravity (face-detection for portrait crops)
+ */
+export const PROFILE_PICTURE_VARIANTS = {
+  thumbnail: { key: 'thumbnail', width: 50, height: 50, crop: 'fill', gravity: 'face' },
+  avatar: { key: 'avatar', width: 200, height: 200, crop: 'fill', gravity: 'face' },
+  full: { key: 'full', width: 800, height: 800, crop: 'limit', gravity: 'auto' },
+} as const;
+
+export type ProfilePictureVariantKey = keyof typeof PROFILE_PICTURE_VARIANTS;
+
+/**
+ * Build a Cloudinary delivery URL with transformation parameters applied.
+ *
+ * We derive variant URLs from the original public_id rather than uploading
+ * multiple times, keeping storage costs low and ensuring consistency.
+ *
+ * @param cloudName  - Cloudinary cloud name (from env)
+ * @param publicId   - The public_id returned by the initial upload
+ * @param variant    - One of the PROFILE_PICTURE_VARIANTS entries
+ */
+export function buildVariantUrl(
+  cloudName: string,
+  publicId: string,
+  variant: (typeof PROFILE_PICTURE_VARIANTS)[ProfilePictureVariantKey],
+): string {
+  const { width, height, crop, gravity } = variant;
+  // Transformation string: w_<n>,h_<n>,c_<mode>,g_<gravity>,q_auto,f_auto
+  const transformation = `w_${width},h_${height},c_${crop},g_${gravity},q_auto,f_auto`;
+  return `https://res.cloudinary.com/${cloudName}/image/upload/${transformation}/${publicId}`;
+}

--- a/backend/src/cloudinary/cloudinary.service.spec.ts
+++ b/backend/src/cloudinary/cloudinary.service.spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { CloudinaryService, ProfilePictureUrls } from './cloudinary.service';
+import { PROFILE_PICTURE_VARIANTS, buildVariantUrl } from './cloudinary.constants';
+
+// ─── Mock cloudinary v2 ──────────────────────────────────────────────────────
+
+const mockUploadStream = jest.fn();
+
+jest.mock('cloudinary', () => ({
+  v2: {
+    config: jest.fn(),
+    uploader: {
+      upload_stream: mockUploadStream,
+    },
+  },
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeFile(overrides: Partial<Express.Multer.File> = {}): Express.Multer.File {
+  return {
+    fieldname: 'file',
+    originalname: 'avatar.jpg',
+    encoding: '7bit',
+    mimetype: 'image/jpeg',
+    size: 1024 * 500, // 500 KB
+    buffer: Buffer.from('fake-image-data'),
+    stream: null as any,
+    destination: '',
+    filename: '',
+    path: '',
+    ...overrides,
+  };
+}
+
+/** Simulate a successful Cloudinary upload_stream call */
+function mockSuccessfulUpload(publicId: string, secureUrl: string) {
+  mockUploadStream.mockImplementation((_opts: any, callback: Function) => {
+    const writable = {
+      end: (buffer: Buffer) => {
+        callback(null, { public_id: publicId, secure_url: secureUrl });
+      },
+    };
+    return writable;
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('CloudinaryService', () => {
+  let service: CloudinaryService;
+  const CLOUD_NAME = 'test-cloud';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CloudinaryService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              const map: Record<string, string> = {
+                CLOUDINARY_CLOUD_NAME: CLOUD_NAME,
+                CLOUDINARY_API_KEY: 'test-key',
+                CLOUDINARY_API_SECRET: 'test-secret',
+              };
+              return map[key];
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CloudinaryService>(CloudinaryService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── uploadProfilePicture ─────────────────────────────────────────────────
+
+  describe('uploadProfilePicture()', () => {
+    it('returns all three variant URLs after a single upload', async () => {
+      const publicId = 'hubassist/profile-pictures/user-abc';
+      mockSuccessfulUpload(publicId, `https://res.cloudinary.com/${CLOUD_NAME}/image/upload/${publicId}`);
+
+      const result: ProfilePictureUrls = await service.uploadProfilePicture(makeFile());
+
+      expect(result).toHaveProperty('thumbnail');
+      expect(result).toHaveProperty('avatar');
+      expect(result).toHaveProperty('full');
+    });
+
+    it('thumbnail URL encodes 50×50 transformation', async () => {
+      const publicId = 'hubassist/profile-pictures/user-abc';
+      mockSuccessfulUpload(publicId, '');
+
+      const result = await service.uploadProfilePicture(makeFile());
+
+      expect(result.thumbnail).toContain('w_50');
+      expect(result.thumbnail).toContain('h_50');
+      expect(result.thumbnail).toContain('g_face');
+    });
+
+    it('avatar URL encodes 200×200 transformation', async () => {
+      const publicId = 'hubassist/profile-pictures/user-abc';
+      mockSuccessfulUpload(publicId, '');
+
+      const result = await service.uploadProfilePicture(makeFile());
+
+      expect(result.avatar).toContain('w_200');
+      expect(result.avatar).toContain('h_200');
+      expect(result.avatar).toContain('g_face');
+    });
+
+    it('full URL encodes 800×800 transformation', async () => {
+      const publicId = 'hubassist/profile-pictures/user-abc';
+      mockSuccessfulUpload(publicId, '');
+
+      const result = await service.uploadProfilePicture(makeFile());
+
+      expect(result.full).toContain('w_800');
+      expect(result.full).toContain('h_800');
+    });
+
+    it('all variant URLs reference the same public_id (single upload)', async () => {
+      const publicId = 'hubassist/profile-pictures/unique-id-xyz';
+      mockSuccessfulUpload(publicId, '');
+
+      const result = await service.uploadProfilePicture(makeFile());
+
+      expect(result.thumbnail).toContain(publicId);
+      expect(result.avatar).toContain(publicId);
+      expect(result.full).toContain(publicId);
+
+      // upload_stream called exactly once – no extra uploads for variants
+      expect(mockUploadStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('variant URLs match buildVariantUrl output exactly', async () => {
+      const publicId = 'hubassist/profile-pictures/user-abc';
+      mockSuccessfulUpload(publicId, '');
+
+      const result = await service.uploadProfilePicture(makeFile());
+
+      expect(result.thumbnail).toBe(buildVariantUrl(CLOUD_NAME, publicId, PROFILE_PICTURE_VARIANTS.thumbnail));
+      expect(result.avatar).toBe(buildVariantUrl(CLOUD_NAME, publicId, PROFILE_PICTURE_VARIANTS.avatar));
+      expect(result.full).toBe(buildVariantUrl(CLOUD_NAME, publicId, PROFILE_PICTURE_VARIANTS.full));
+    });
+
+    it('rejects when Cloudinary returns an error', async () => {
+      mockUploadStream.mockImplementation((_opts: any, callback: Function) => ({
+        end: () => callback(new Error('Cloudinary network error'), undefined),
+      }));
+
+      await expect(service.uploadProfilePicture(makeFile())).rejects.toThrow(
+        'Cloudinary network error',
+      );
+    });
+  });
+
+  // ── uploadImage (legacy) ─────────────────────────────────────────────────
+
+  describe('uploadImage() – legacy', () => {
+    it('returns a secure_url string', async () => {
+      const secureUrl = 'https://res.cloudinary.com/test-cloud/image/upload/v1/hubassist/profile-pictures/abc';
+      mockSuccessfulUpload('hubassist/profile-pictures/abc', secureUrl);
+
+      const result = await service.uploadImage(makeFile());
+
+      expect(typeof result).toBe('string');
+      expect(result).toBe(secureUrl);
+    });
+  });
+});

--- a/backend/src/cloudinary/cloudinary.service.ts
+++ b/backend/src/cloudinary/cloudinary.service.ts
@@ -1,24 +1,87 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { v2 as cloudinary } from 'cloudinary';
+import { v2 as cloudinary, UploadApiResponse } from 'cloudinary';
+import {
+  CLOUDINARY_PROFILE_FOLDER,
+  PROFILE_PICTURE_VARIANTS,
+  buildVariantUrl,
+} from './cloudinary.constants';
+
+export interface ProfilePictureUrls {
+  /** 50×50 thumbnail – use for comment avatars, notification icons, etc. */
+  thumbnail: string;
+  /** 200×200 avatar – use for profile headers, user cards, etc. */
+  avatar: string;
+  /** 800×800 full – use for profile detail pages. */
+  full: string;
+}
 
 @Injectable()
 export class CloudinaryService {
+  private cloudName: string;
+
   constructor(private configService: ConfigService) {
+    this.cloudName = this.configService.get<string>('CLOUDINARY_CLOUD_NAME') ?? '';
+
     cloudinary.config({
-      cloud_name: this.configService.get('CLOUDINARY_CLOUD_NAME'),
+      cloud_name: this.cloudName,
       api_key: this.configService.get('CLOUDINARY_API_KEY'),
       api_secret: this.configService.get('CLOUDINARY_API_SECRET'),
     });
   }
 
+  /**
+   * Legacy single-URL upload – kept for backward compatibility.
+   * New code should use `uploadProfilePicture()` instead.
+   *
+   * @deprecated Use uploadProfilePicture() which returns all variant URLs.
+   */
   async uploadImage(file: Express.Multer.File): Promise<string> {
+    const result = await this.uploadToCloudinary(file);
+    return result.secure_url;
+  }
+
+  /**
+   * Upload a profile picture once and derive three variant URLs via
+   * Cloudinary URL transformation strings (no extra upload requests).
+   *
+   * Upload options applied:
+   *  - `angle: 'exif'`  – auto-correct orientation from EXIF data
+   *  - `face` gravity   – auto-crop to the subject's face for thumbnail/avatar
+   *  - `quality: 'auto'` – Cloudinary picks the optimal quality level
+   *
+   * @returns ProfilePictureUrls with thumbnail (50×50), avatar (200×200), full (800×800)
+   */
+  async uploadProfilePicture(file: Express.Multer.File): Promise<ProfilePictureUrls> {
+    const result = await this.uploadToCloudinary(file, {
+      // Correct orientation from EXIF metadata
+      transformation: [{ angle: 'exif' }],
+    });
+
+    const publicId = result.public_id;
+
+    return {
+      thumbnail: buildVariantUrl(this.cloudName, publicId, PROFILE_PICTURE_VARIANTS.thumbnail),
+      avatar: buildVariantUrl(this.cloudName, publicId, PROFILE_PICTURE_VARIANTS.avatar),
+      full: buildVariantUrl(this.cloudName, publicId, PROFILE_PICTURE_VARIANTS.full),
+    };
+  }
+
+  // ─── private ──────────────────────────────────────────────────────────────
+
+  private uploadToCloudinary(
+    file: Express.Multer.File,
+    extraOptions: Record<string, unknown> = {},
+  ): Promise<UploadApiResponse> {
     return new Promise((resolve, reject) => {
       const upload = cloudinary.uploader.upload_stream(
-        { folder: 'hubassist/profile-pictures' },
-        (error: any, result: any) => {
-          if (error) reject(error);
-          else resolve(result?.secure_url || '');
+        {
+          folder: CLOUDINARY_PROFILE_FOLDER,
+          ...extraOptions,
+        },
+        (error: any, result: UploadApiResponse | undefined) => {
+          if (error || !result) reject(error ?? new Error('Cloudinary upload failed'));
+          else resolve(result);
         },
       );
       upload.end(file.buffer);

--- a/backend/src/migrations/1748500000000-AddRevenueReportingIndexes.ts
+++ b/backend/src/migrations/1748500000000-AddRevenueReportingIndexes.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds indexes that support the admin revenue reporting queries:
+ *
+ *  - idx_bookings_starttime_status_amount  – covers the date-range + status filter
+ *    used by GET /admin/reports/revenue.  The partial index excludes Cancelled
+ *    bookings to keep it lean.
+ *
+ *  - idx_bookings_starttime_workspaceid    – supports the JOIN to workspaces when
+ *    filtering by workspaceType.
+ *
+ * Both indexes use CONCURRENTLY to avoid locking in production.
+ */
+export class AddRevenueReportingIndexes1748500000000 implements MigrationInterface {
+  name = 'AddRevenueReportingIndexes1748500000000';
+  transaction = false; // required for CONCURRENTLY
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Covers: WHERE startTime BETWEEN :start AND :end AND status = :status
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_bookings_starttime_status"
+      ON "bookings" ("startTime", "status")
+      WHERE "status" != 'Cancelled'
+    `);
+
+    // Covers: WHERE startTime BETWEEN :start AND :end (workspace join path)
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_bookings_starttime_workspaceid"
+      ON "bookings" ("startTime", "workspaceId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "idx_bookings_starttime_workspaceid"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "idx_bookings_starttime_status"`,
+    );
+  }
+}

--- a/backend/src/migrations/1748600000000-AddProfilePictureUrls.ts
+++ b/backend/src/migrations/1748600000000-AddProfilePictureUrls.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the `profilePictureUrls` JSONB column to the `users` table and
+ * migrates any existing single-URL `profilePicture` values into the new
+ * JSONB format.
+ *
+ * Migration strategy:
+ *  1. Add the nullable `profilePictureUrls` JSONB column.
+ *  2. For every row that already has a `profilePicture` URL, populate
+ *     `profilePictureUrls` with the existing URL placed in all three
+ *     variant slots (thumbnail, avatar, full).  This is a safe fallback –
+ *     the next time the user uploads a new picture the proper Cloudinary
+ *     transformation URLs will replace these values.
+ *  3. The old `profilePicture` column is intentionally kept so that any
+ *     existing API consumers that read it continue to work unchanged.
+ *
+ * Rollback: drops the `profilePictureUrls` column (the old column is untouched).
+ */
+export class AddProfilePictureUrls1748600000000 implements MigrationInterface {
+  name = 'AddProfilePictureUrls1748600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Add the new JSONB column
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      ADD COLUMN IF NOT EXISTS "profilePictureUrls" jsonb
+    `);
+
+    // 2. Migrate existing single-URL data into the JSONB format.
+    //    We use the existing URL for all three variants as a safe placeholder.
+    await queryRunner.query(`
+      UPDATE "users"
+      SET "profilePictureUrls" = jsonb_build_object(
+        'thumbnail', "profilePicture",
+        'avatar',    "profilePicture",
+        'full',      "profilePicture"
+      )
+      WHERE "profilePicture" IS NOT NULL
+        AND "profilePictureUrls" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      DROP COLUMN IF EXISTS "profilePictureUrls"
+    `);
+  }
+}

--- a/backend/src/reports/dto/occupancy-query.dto.ts
+++ b/backend/src/reports/dto/occupancy-query.dto.ts
@@ -1,0 +1,30 @@
+import { IsOptional, IsDateString, IsEnum } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { WorkspaceType } from '../../workspaces/workspace.entity';
+
+export class OccupancyQueryDto {
+  @ApiPropertyOptional({
+    description: 'Start of the date range (ISO 8601). Defaults to 30 days ago.',
+    example: '2024-01-01',
+  })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'End of the date range (ISO 8601). Defaults to today.',
+    example: '2024-01-31',
+  })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by workspace type.',
+    enum: WorkspaceType,
+    example: WorkspaceType.MEETING_ROOM,
+  })
+  @IsOptional()
+  @IsEnum(WorkspaceType)
+  workspaceType?: WorkspaceType;
+}

--- a/backend/src/reports/dto/revenue-query.dto.ts
+++ b/backend/src/reports/dto/revenue-query.dto.ts
@@ -1,0 +1,52 @@
+import { IsOptional, IsDateString, IsEnum, IsIn } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { BookingStatus } from '../../bookings/booking.entity';
+import { WorkspaceType } from '../../workspaces/workspace.entity';
+
+export type GroupBy = 'day' | 'week' | 'month';
+
+export class RevenueQueryDto {
+  @ApiPropertyOptional({
+    description: 'Start of the date range (ISO 8601). Defaults to 30 days ago.',
+    example: '2024-01-01',
+  })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'End of the date range (ISO 8601). Defaults to today.',
+    example: '2024-01-31',
+  })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by workspace type.',
+    enum: WorkspaceType,
+    example: WorkspaceType.HOT_DESK,
+  })
+  @IsOptional()
+  @IsEnum(WorkspaceType)
+  workspaceType?: WorkspaceType;
+
+  @ApiPropertyOptional({
+    description: 'Filter by booking status.',
+    enum: BookingStatus,
+    example: BookingStatus.CONFIRMED,
+  })
+  @IsOptional()
+  @IsEnum(BookingStatus)
+  status?: BookingStatus;
+
+  @ApiPropertyOptional({
+    description: 'Aggregation granularity: day, week, or month.',
+    enum: ['day', 'week', 'month'],
+    default: 'day',
+    example: 'day',
+  })
+  @IsOptional()
+  @IsIn(['day', 'week', 'month'])
+  groupBy?: GroupBy = 'day';
+}

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -1,0 +1,189 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Res,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { Response } from 'express';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiResponse,
+  ApiProduces,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { CacheInterceptor, CacheKey, CacheTTL } from '@nestjs/cache-manager';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '../users/user.entity';
+import { ReportsService } from './reports.service';
+import { RevenueQueryDto } from './dto/revenue-query.dto';
+import { OccupancyQueryDto } from './dto/occupancy-query.dto';
+import { BookingStatus } from '../bookings/booking.entity';
+import { WorkspaceType } from '../workspaces/workspace.entity';
+
+@ApiTags('admin / reports')
+@ApiBearerAuth('bearer')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+@Controller({ version: '1', path: 'admin/reports' })
+export class ReportsController {
+  constructor(private readonly reportsService: ReportsService) {}
+
+  // ─── Revenue ──────────────────────────────────────────────────────────────
+
+  @Get('revenue')
+  @UseInterceptors(CacheInterceptor)
+  @CacheKey('reports:revenue')
+  @CacheTTL(300) // 5-minute TTL as required
+  @ApiOperation({
+    summary: 'Aggregated revenue report (admin only)',
+    description: `Returns revenue totals grouped by day, week, or month for the given date range.
+
+**Filters**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| startDate | ISO date | Start of range (default: 30 days ago) |
+| endDate | ISO date | End of range (default: today) |
+| workspaceType | enum | Filter by workspace type |
+| status | enum | Filter by booking status |
+| groupBy | day \\| week \\| month | Aggregation granularity (default: day) |
+
+**Performance**: Uses the \`idx_bookings_workspaceid_starttime_endtime\` index for date-range filtering.
+
+**Security**: Admin-only endpoint. Returns 403 for non-admin roles.`,
+  })
+  @ApiQuery({ name: 'startDate', required: false, example: '2024-01-01', description: 'Start date (ISO 8601)' })
+  @ApiQuery({ name: 'endDate', required: false, example: '2024-01-31', description: 'End date (ISO 8601)' })
+  @ApiQuery({ name: 'workspaceType', required: false, enum: WorkspaceType, description: 'Filter by workspace type' })
+  @ApiQuery({ name: 'status', required: false, enum: BookingStatus, description: 'Filter by booking status' })
+  @ApiQuery({ name: 'groupBy', required: false, enum: ['day', 'week', 'month'], description: 'Aggregation granularity' })
+  @ApiResponse({
+    status: 200,
+    description: 'Revenue report retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        summary: {
+          type: 'object',
+          properties: {
+            totalRevenue: { type: 'number', example: 12500.0 },
+            totalBookings: { type: 'number', example: 87 },
+            averageBookingValue: { type: 'number', example: 143.68 },
+            startDate: { type: 'string', example: '2024-01-01' },
+            endDate: { type: 'string', example: '2024-01-31' },
+          },
+        },
+        breakdown: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              period: { type: 'string', example: '2024-01-15' },
+              totalRevenue: { type: 'number', example: 450.0 },
+              bookingCount: { type: 'number', example: 3 },
+              averageBookingValue: { type: 'number', example: 150.0 },
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  getRevenue(@Query() query: RevenueQueryDto) {
+    return this.reportsService.getRevenue(query);
+  }
+
+  // ─── Revenue CSV Export ───────────────────────────────────────────────────
+
+  @Get('revenue/export')
+  @ApiOperation({
+    summary: 'Export revenue report as CSV (admin only)',
+    description: `Streams a CSV file with the same filters as GET /admin/reports/revenue.
+
+The response includes a \`Content-Disposition: attachment; filename="revenue-report-<date>.csv"\` header.
+
+**CSV columns**: period, totalRevenue, bookingCount, averageBookingValue`,
+  })
+  @ApiProduces('text/csv')
+  @ApiQuery({ name: 'startDate', required: false, example: '2024-01-01', description: 'Start date (ISO 8601)' })
+  @ApiQuery({ name: 'endDate', required: false, example: '2024-01-31', description: 'End date (ISO 8601)' })
+  @ApiQuery({ name: 'workspaceType', required: false, enum: WorkspaceType, description: 'Filter by workspace type' })
+  @ApiQuery({ name: 'status', required: false, enum: BookingStatus, description: 'Filter by booking status' })
+  @ApiQuery({ name: 'groupBy', required: false, enum: ['day', 'week', 'month'], description: 'Aggregation granularity' })
+  @ApiResponse({ status: 200, description: 'CSV file streamed successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  async exportRevenueCsv(@Query() query: RevenueQueryDto, @Res() res: Response) {
+    const csv = await this.reportsService.getRevenueCsv(query);
+    const dateTag = new Date().toISOString().split('T')[0];
+    const filename = `revenue-report-${dateTag}.csv`;
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Cache-Control', 'no-store');
+    res.send(csv);
+  }
+
+  // ─── Occupancy ────────────────────────────────────────────────────────────
+
+  @Get('occupancy')
+  @UseInterceptors(CacheInterceptor)
+  @CacheKey('reports:occupancy')
+  @CacheTTL(300) // 5-minute TTL
+  @ApiOperation({
+    summary: 'Workspace utilization / occupancy report (admin only)',
+    description: `Returns utilization percentages for each active workspace over the given period.
+
+**Utilization formula**: (total confirmed booked hours) / (period hours × capacity) × 100
+
+**Filters**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| startDate | ISO date | Start of range (default: 30 days ago) |
+| endDate | ISO date | End of range (default: today) |
+| workspaceType | enum | Filter by workspace type |`,
+  })
+  @ApiQuery({ name: 'startDate', required: false, example: '2024-01-01', description: 'Start date (ISO 8601)' })
+  @ApiQuery({ name: 'endDate', required: false, example: '2024-01-31', description: 'End date (ISO 8601)' })
+  @ApiQuery({ name: 'workspaceType', required: false, enum: WorkspaceType, description: 'Filter by workspace type' })
+  @ApiResponse({
+    status: 200,
+    description: 'Occupancy report retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        startDate: { type: 'string', example: '2024-01-01' },
+        endDate: { type: 'string', example: '2024-01-31' },
+        overallUtilizationPct: { type: 'number', example: 42.5 },
+        workspaces: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              workspaceId: { type: 'string', format: 'uuid' },
+              workspaceName: { type: 'string', example: 'Hot Desk A' },
+              workspaceType: { type: 'string', enum: Object.values(WorkspaceType) },
+              capacity: { type: 'number', example: 4 },
+              totalBookings: { type: 'number', example: 12 },
+              confirmedBookings: { type: 'number', example: 10 },
+              totalBookedHours: { type: 'number', example: 80.0 },
+              availableHours: { type: 'number', example: 744.0 },
+              utilizationPct: { type: 'number', example: 10.8 },
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  getOccupancy(@Query() query: OccupancyQueryDto) {
+    return this.reportsService.getOccupancy(query);
+  }
+}

--- a/backend/src/reports/reports.module.ts
+++ b/backend/src/reports/reports.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Booking } from '../bookings/booking.entity';
+import { Workspace } from '../workspaces/workspace.entity';
+import { ReportsService } from './reports.service';
+import { ReportsController } from './reports.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Booking, Workspace])],
+  providers: [ReportsService],
+  controllers: [ReportsController],
+})
+export class ReportsModule {}

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -1,0 +1,310 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ReportsService } from './reports.service';
+import { Booking, BookingStatus } from '../bookings/booking.entity';
+import { Workspace, WorkspaceType } from '../workspaces/workspace.entity';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeBooking(overrides: Partial<Booking> = {}): Booking {
+  return {
+    id: 'b1',
+    workspaceId: 'ws1',
+    userId: 'u1',
+    startTime: new Date('2024-01-15T09:00:00Z'),
+    endTime: new Date('2024-01-15T11:00:00Z'),
+    status: BookingStatus.CONFIRMED,
+    totalAmount: 200,
+    stellarTxHash: null as any,
+    hubId: undefined,
+    createdAt: new Date('2024-01-15'),
+    updatedAt: new Date('2024-01-15'),
+    workspace: {} as any,
+    user: {} as any,
+    ...overrides,
+  };
+}
+
+// ─── Mock QueryBuilder factory ───────────────────────────────────────────────
+
+function makeQb(rawResult: any[]) {
+  const qb: any = {
+    innerJoin: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue(rawResult),
+    getMany: jest.fn().mockResolvedValue([]),
+  };
+  return qb;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ReportsService', () => {
+  let service: ReportsService;
+  let bookingQbFactory: jest.Mock;
+  let workspaceQbFactory: jest.Mock;
+
+  const mockBookingRepo = {
+    createQueryBuilder: jest.fn(),
+  };
+
+  const mockWorkspaceRepo = {
+    createQueryBuilder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportsService,
+        { provide: getRepositoryToken(Booking), useValue: mockBookingRepo },
+        { provide: getRepositoryToken(Workspace), useValue: mockWorkspaceRepo },
+      ],
+    }).compile();
+
+    service = module.get<ReportsService>(ReportsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── Revenue aggregation ──────────────────────────────────────────────────
+
+  describe('getRevenue()', () => {
+    it('returns correct totals for a mocked booking dataset', async () => {
+      const rawRows = [
+        { period: '2024-01-10', totalRevenue: '300.00', bookingCount: '2' },
+        { period: '2024-01-15', totalRevenue: '450.00', bookingCount: '3' },
+        { period: '2024-01-20', totalRevenue: '150.00', bookingCount: '1' },
+      ];
+
+      mockBookingRepo.createQueryBuilder.mockReturnValue(makeQb(rawRows));
+
+      const result = await service.getRevenue({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        groupBy: 'day',
+      });
+
+      expect(result.summary.totalRevenue).toBe(900);
+      expect(result.summary.totalBookings).toBe(6);
+      expect(result.summary.averageBookingValue).toBe(150);
+      expect(result.breakdown).toHaveLength(3);
+    });
+
+    it('returns zero totals when no bookings exist in range', async () => {
+      mockBookingRepo.createQueryBuilder.mockReturnValue(makeQb([]));
+
+      const result = await service.getRevenue({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
+
+      expect(result.summary.totalRevenue).toBe(0);
+      expect(result.summary.totalBookings).toBe(0);
+      expect(result.summary.averageBookingValue).toBe(0);
+      expect(result.breakdown).toHaveLength(0);
+    });
+
+    it('applies workspaceType filter to query builder', async () => {
+      const qb = makeQb([]);
+      mockBookingRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getRevenue({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        workspaceType: WorkspaceType.HOT_DESK,
+      });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'workspace.type = :workspaceType',
+        { workspaceType: WorkspaceType.HOT_DESK },
+      );
+    });
+
+    it('applies status filter to query builder', async () => {
+      const qb = makeQb([]);
+      mockBookingRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getRevenue({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        status: BookingStatus.CONFIRMED,
+      });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('booking.status = :status', {
+        status: BookingStatus.CONFIRMED,
+      });
+    });
+
+    it('groups by month when groupBy=month', async () => {
+      const qb = makeQb([{ period: '2024-01', totalRevenue: '900.00', bookingCount: '6' }]);
+      mockBookingRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getRevenue({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        groupBy: 'month',
+      });
+
+      expect(result.breakdown[0].period).toBe('2024-01');
+    });
+
+    it('date filter: only January bookings returned for startDate=2024-01-01&endDate=2024-01-31', async () => {
+      // Simulate DB returning only January rows (the WHERE clause is enforced by the DB;
+      // here we verify the query builder receives the correct date bounds).
+      const qb = makeQb([
+        { period: '2024-01-05', totalRevenue: '200.00', bookingCount: '1' },
+        { period: '2024-01-20', totalRevenue: '400.00', bookingCount: '2' },
+      ]);
+      mockBookingRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getRevenue({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
+
+      // Verify the where clause was called with January bounds
+      expect(qb.where).toHaveBeenCalledWith('booking.startTime >= :start', expect.objectContaining({
+        start: expect.any(Date),
+      }));
+      expect(qb.andWhere).toHaveBeenCalledWith('booking.startTime <= :end', expect.objectContaining({
+        end: expect.any(Date),
+      }));
+
+      // All returned periods should be in January 2024
+      result.breakdown.forEach((row) => {
+        expect(row.period.startsWith('2024-01')).toBe(true);
+      });
+
+      expect(result.summary.totalRevenue).toBe(600);
+      expect(result.summary.totalBookings).toBe(3);
+    });
+  });
+
+  // ── CSV export ───────────────────────────────────────────────────────────
+
+  describe('getRevenueCsv()', () => {
+    it('CSV headers and row count match the JSON endpoint', async () => {
+      const rawRows = [
+        { period: '2024-01-10', totalRevenue: '300.00', bookingCount: '2' },
+        { period: '2024-01-15', totalRevenue: '450.00', bookingCount: '3' },
+      ];
+      mockBookingRepo.createQueryBuilder.mockReturnValue(makeQb(rawRows));
+
+      const csv = await service.getRevenueCsv({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
+
+      const lines = csv.split('\n').filter((l) => l && !l.startsWith('#'));
+      const [header, ...dataRows] = lines;
+
+      // Verify headers
+      expect(header).toBe('period,totalRevenue,bookingCount,averageBookingValue');
+
+      // Row count matches breakdown length
+      expect(dataRows).toHaveLength(rawRows.length);
+
+      // Verify first data row
+      expect(dataRows[0]).toBe('2024-01-10,300,2,150');
+    });
+
+    it('CSV is empty (only headers) when no bookings exist', async () => {
+      mockBookingRepo.createQueryBuilder.mockReturnValue(makeQb([]));
+
+      const csv = await service.getRevenueCsv({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
+
+      const lines = csv.split('\n').filter((l) => l && !l.startsWith('#'));
+      expect(lines).toHaveLength(1); // only the header row
+      expect(lines[0]).toBe('period,totalRevenue,bookingCount,averageBookingValue');
+    });
+  });
+
+  // ── Occupancy ────────────────────────────────────────────────────────────
+
+  describe('getOccupancy()', () => {
+    const mockWorkspace = {
+      id: 'ws1',
+      name: 'Hot Desk A',
+      type: WorkspaceType.HOT_DESK,
+      capacity: 4,
+      isActive: true,
+      deletedAt: null,
+    } as Workspace;
+
+    it('calculates utilization percentage correctly', async () => {
+      const wsQb: any = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockWorkspace]),
+      };
+      const bookingQb: any = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            workspaceId: 'ws1',
+            totalBookings: '5',
+            confirmedBookings: '4',
+            totalBookedHours: '16.0',
+          },
+        ]),
+      };
+
+      mockWorkspaceRepo.createQueryBuilder.mockReturnValue(wsQb);
+      mockBookingRepo.createQueryBuilder.mockReturnValue(bookingQb);
+
+      const result = await service.getOccupancy({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
+
+      expect(result.workspaces).toHaveLength(1);
+      const ws = result.workspaces[0];
+      expect(ws.workspaceId).toBe('ws1');
+      expect(ws.confirmedBookings).toBe(4);
+      expect(ws.totalBookedHours).toBe(16);
+      // availableHours = 744 hours in Jan × 4 capacity = 2976
+      // utilizationPct = 16 / 2976 * 100 ≈ 0.5
+      expect(ws.utilizationPct).toBeGreaterThanOrEqual(0);
+      expect(ws.utilizationPct).toBeLessThanOrEqual(100);
+    });
+
+    it('returns zero utilization when no bookings exist', async () => {
+      const wsQb: any = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockWorkspace]),
+      };
+      const bookingQb: any = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      mockWorkspaceRepo.createQueryBuilder.mockReturnValue(wsQb);
+      mockBookingRepo.createQueryBuilder.mockReturnValue(bookingQb);
+
+      const result = await service.getOccupancy({
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      });
+
+      expect(result.workspaces[0].utilizationPct).toBe(0);
+      expect(result.overallUtilizationPct).toBe(0);
+    });
+  });
+});

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -1,0 +1,248 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Booking, BookingStatus } from '../bookings/booking.entity';
+import { Workspace, WorkspaceType } from '../workspaces/workspace.entity';
+import { RevenueQueryDto, GroupBy } from './dto/revenue-query.dto';
+import { OccupancyQueryDto } from './dto/occupancy-query.dto';
+
+export interface RevenuePeriod {
+  period: string;
+  totalRevenue: number;
+  bookingCount: number;
+  averageBookingValue: number;
+}
+
+export interface RevenueReport {
+  summary: {
+    totalRevenue: number;
+    totalBookings: number;
+    averageBookingValue: number;
+    startDate: string;
+    endDate: string;
+  };
+  breakdown: RevenuePeriod[];
+}
+
+export interface WorkspaceOccupancy {
+  workspaceId: string;
+  workspaceName: string;
+  workspaceType: WorkspaceType;
+  capacity: number;
+  totalBookings: number;
+  confirmedBookings: number;
+  totalBookedHours: number;
+  availableHours: number;
+  utilizationPct: number;
+}
+
+export interface OccupancyReport {
+  startDate: string;
+  endDate: string;
+  workspaces: WorkspaceOccupancy[];
+  overallUtilizationPct: number;
+}
+
+/** Map groupBy granularity to a Postgres DATE_TRUNC truncation unit. */
+function truncUnit(groupBy: GroupBy): string {
+  if (groupBy === 'week') return 'week';
+  if (groupBy === 'month') return 'month';
+  return 'day';
+}
+
+/** Format a DATE_TRUNC result label for the response. */
+function periodFormat(groupBy: GroupBy): string {
+  if (groupBy === 'month') return "YYYY-MM";
+  if (groupBy === 'week') return "IYYY-IW"; // ISO year + ISO week number
+  return "YYYY-MM-DD";
+}
+
+@Injectable()
+export class ReportsService {
+  constructor(
+    @InjectRepository(Booking) private bookingRepo: Repository<Booking>,
+    @InjectRepository(Workspace) private workspaceRepo: Repository<Workspace>,
+  ) {}
+
+  // ─── helpers ────────────────────────────────────────────────────────────────
+
+  private resolveDateRange(startDate?: string, endDate?: string): { start: Date; end: Date } {
+    const end = endDate ? new Date(endDate) : new Date();
+    // Set end to end-of-day so the filter is inclusive
+    end.setHours(23, 59, 59, 999);
+
+    const start = startDate
+      ? new Date(startDate)
+      : new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000);
+    start.setHours(0, 0, 0, 0);
+
+    return { start, end };
+  }
+
+  // ─── revenue ────────────────────────────────────────────────────────────────
+
+  async getRevenue(query: RevenueQueryDto): Promise<RevenueReport> {
+    const { start, end } = this.resolveDateRange(query.startDate, query.endDate);
+    const groupBy: GroupBy = query.groupBy ?? 'day';
+    const trunc = truncUnit(groupBy);
+    const fmt = periodFormat(groupBy);
+
+    // Build the aggregation query using DB-level GROUP BY + SUM.
+    // The startTime index (idx_bookings_workspaceid_starttime_endtime) covers
+    // the date-range predicate, avoiding full table scans.
+    const qb = this.bookingRepo
+      .createQueryBuilder('booking')
+      .innerJoin('booking.workspace', 'workspace')
+      .select(`TO_CHAR(DATE_TRUNC('${trunc}', booking.startTime), '${fmt}')`, 'period')
+      .addSelect('SUM(booking.totalAmount)', 'totalRevenue')
+      .addSelect('COUNT(booking.id)', 'bookingCount')
+      .where('booking.startTime >= :start', { start })
+      .andWhere('booking.startTime <= :end', { end })
+      .groupBy(`DATE_TRUNC('${trunc}', booking.startTime)`)
+      .orderBy(`DATE_TRUNC('${trunc}', booking.startTime)`, 'ASC');
+
+    if (query.workspaceType) {
+      qb.andWhere('workspace.type = :workspaceType', { workspaceType: query.workspaceType });
+    }
+
+    if (query.status) {
+      qb.andWhere('booking.status = :status', { status: query.status });
+    }
+
+    const rows = await qb.getRawMany();
+
+    const breakdown: RevenuePeriod[] = rows.map((r) => {
+      const revenue = parseFloat(r.totalRevenue) || 0;
+      const count = parseInt(r.bookingCount, 10) || 0;
+      return {
+        period: r.period,
+        totalRevenue: revenue,
+        bookingCount: count,
+        averageBookingValue: count > 0 ? parseFloat((revenue / count).toFixed(2)) : 0,
+      };
+    });
+
+    const totalRevenue = breakdown.reduce((sum, r) => sum + r.totalRevenue, 0);
+    const totalBookings = breakdown.reduce((sum, r) => sum + r.bookingCount, 0);
+
+    return {
+      summary: {
+        totalRevenue: parseFloat(totalRevenue.toFixed(2)),
+        totalBookings,
+        averageBookingValue:
+          totalBookings > 0 ? parseFloat((totalRevenue / totalBookings).toFixed(2)) : 0,
+        startDate: start.toISOString().split('T')[0],
+        endDate: end.toISOString().split('T')[0],
+      },
+      breakdown,
+    };
+  }
+
+  // ─── CSV export ─────────────────────────────────────────────────────────────
+
+  async getRevenueCsv(query: RevenueQueryDto): Promise<string> {
+    const report = await this.getRevenue(query);
+
+    const header = 'period,totalRevenue,bookingCount,averageBookingValue';
+    const rows = report.breakdown.map(
+      (r) => `${r.period},${r.totalRevenue},${r.bookingCount},${r.averageBookingValue}`,
+    );
+
+    // Prepend summary rows for context
+    const summaryRows = [
+      `# Revenue Report: ${report.summary.startDate} to ${report.summary.endDate}`,
+      `# Total Revenue: ${report.summary.totalRevenue}`,
+      `# Total Bookings: ${report.summary.totalBookings}`,
+      `# Average Booking Value: ${report.summary.averageBookingValue}`,
+      '',
+    ];
+
+    return [...summaryRows, header, ...rows].join('\n');
+  }
+
+  // ─── occupancy ──────────────────────────────────────────────────────────────
+
+  async getOccupancy(query: OccupancyQueryDto): Promise<OccupancyReport> {
+    const { start, end } = this.resolveDateRange(query.startDate, query.endDate);
+
+    // Total hours in the period (used to compute available hours per workspace)
+    const periodHours =
+      Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60) * 10) / 10;
+
+    const wsQb = this.workspaceRepo
+      .createQueryBuilder('workspace')
+      .where('workspace.isActive = true')
+      .andWhere('workspace.deletedAt IS NULL');
+
+    if (query.workspaceType) {
+      wsQb.andWhere('workspace.type = :workspaceType', { workspaceType: query.workspaceType });
+    }
+
+    const workspaces = await wsQb.getMany();
+
+    // Aggregate bookings per workspace in a single query
+    const bookingQb = this.bookingRepo
+      .createQueryBuilder('booking')
+      .select('booking.workspaceId', 'workspaceId')
+      .addSelect('COUNT(booking.id)', 'totalBookings')
+      .addSelect(
+        `SUM(CASE WHEN booking.status = '${BookingStatus.CONFIRMED}' THEN 1 ELSE 0 END)`,
+        'confirmedBookings',
+      )
+      .addSelect(
+        `SUM(CASE WHEN booking.status = '${BookingStatus.CONFIRMED}' THEN EXTRACT(EPOCH FROM (booking.endTime - booking.startTime)) / 3600 ELSE 0 END)`,
+        'totalBookedHours',
+      )
+      .where('booking.startTime >= :start', { start })
+      .andWhere('booking.startTime <= :end', { end })
+      .groupBy('booking.workspaceId');
+
+    if (workspaces.length > 0) {
+      bookingQb.andWhere('booking.workspaceId IN (:...wsIds)', {
+        wsIds: workspaces.map((w) => w.id),
+      });
+    }
+
+    const bookingStats = await bookingQb.getRawMany();
+    const statsMap = new Map(bookingStats.map((s) => [s.workspaceId, s]));
+
+    const wsOccupancy: WorkspaceOccupancy[] = workspaces.map((ws) => {
+      const stats = statsMap.get(ws.id);
+      const totalBookings = stats ? parseInt(stats.totalBookings, 10) : 0;
+      const confirmedBookings = stats ? parseInt(stats.confirmedBookings, 10) : 0;
+      const totalBookedHours = stats ? parseFloat(stats.totalBookedHours) || 0 : 0;
+      // Available hours = period hours × capacity (each capacity slot is independently bookable)
+      const availableHours = periodHours * ws.capacity;
+      const utilizationPct =
+        availableHours > 0
+          ? Math.min(100, parseFloat(((totalBookedHours / availableHours) * 100).toFixed(1)))
+          : 0;
+
+      return {
+        workspaceId: ws.id,
+        workspaceName: ws.name,
+        workspaceType: ws.type,
+        capacity: ws.capacity,
+        totalBookings,
+        confirmedBookings,
+        totalBookedHours: parseFloat(totalBookedHours.toFixed(1)),
+        availableHours: parseFloat(availableHours.toFixed(1)),
+        utilizationPct,
+      };
+    });
+
+    const totalAvailable = wsOccupancy.reduce((s, w) => s + w.availableHours, 0);
+    const totalBooked = wsOccupancy.reduce((s, w) => s + w.totalBookedHours, 0);
+    const overallUtilizationPct =
+      totalAvailable > 0
+        ? Math.min(100, parseFloat(((totalBooked / totalAvailable) * 100).toFixed(1)))
+        : 0;
+
+    return {
+      startDate: start.toISOString().split('T')[0],
+      endDate: end.toISOString().split('T')[0],
+      workspaces: wsOccupancy,
+      overallUtilizationPct,
+    };
+  }
+}

--- a/backend/src/users/providers/upload-profile-picture.provider.spec.ts
+++ b/backend/src/users/providers/upload-profile-picture.provider.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { UploadProfilePictureProvider } from './upload-profile-picture.provider';
+import { User, UserRole } from '../user.entity';
+import { ProfilePictureUrls } from '../../cloudinary/cloudinary.service';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    email: 'test@example.com',
+    passwordHash: 'hash',
+    role: UserRole.MEMBER,
+    isVerified: true,
+    isActive: true,
+    profilePicture: undefined,
+    profilePictureUrls: undefined,
+    createdAt: new Date(),
+    ...overrides,
+  } as User;
+}
+
+const MOCK_URLS: ProfilePictureUrls = {
+  thumbnail: 'https://res.cloudinary.com/demo/image/upload/w_50,h_50,c_fill,g_face,q_auto,f_auto/hubassist/profile-pictures/abc',
+  avatar: 'https://res.cloudinary.com/demo/image/upload/w_200,h_200,c_fill,g_face,q_auto,f_auto/hubassist/profile-pictures/abc',
+  full: 'https://res.cloudinary.com/demo/image/upload/w_800,h_800,c_limit,g_auto,q_auto,f_auto/hubassist/profile-pictures/abc',
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('UploadProfilePictureProvider', () => {
+  let provider: UploadProfilePictureProvider;
+
+  const mockRepo = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UploadProfilePictureProvider,
+        { provide: getRepositoryToken(User), useValue: mockRepo },
+      ],
+    }).compile();
+
+    provider = module.get<UploadProfilePictureProvider>(UploadProfilePictureProvider);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── URL persistence ──────────────────────────────────────────────────────
+
+  describe('execute()', () => {
+    it('persists all three variant URLs on the user record', async () => {
+      const user = makeUser();
+      mockRepo.findOne.mockResolvedValue(user);
+      mockRepo.save.mockImplementation((u: User) => Promise.resolve(u));
+
+      const result = await provider.execute('user-1', MOCK_URLS);
+
+      expect(result.profilePictureUrls).toEqual(MOCK_URLS);
+      expect(result.profilePictureUrls?.thumbnail).toBe(MOCK_URLS.thumbnail);
+      expect(result.profilePictureUrls?.avatar).toBe(MOCK_URLS.avatar);
+      expect(result.profilePictureUrls?.full).toBe(MOCK_URLS.full);
+    });
+
+    it('sets legacy profilePicture to the avatar variant URL (backward compat)', async () => {
+      const user = makeUser();
+      mockRepo.findOne.mockResolvedValue(user);
+      mockRepo.save.mockImplementation((u: User) => Promise.resolve(u));
+
+      const result = await provider.execute('user-1', MOCK_URLS);
+
+      // Old single-URL field must equal the avatar variant
+      expect(result.profilePicture).toBe(MOCK_URLS.avatar);
+    });
+
+    it('calls repo.save with the updated user', async () => {
+      const user = makeUser();
+      mockRepo.findOne.mockResolvedValue(user);
+      mockRepo.save.mockResolvedValue({ ...user, profilePictureUrls: MOCK_URLS });
+
+      await provider.execute('user-1', MOCK_URLS);
+
+      expect(mockRepo.save).toHaveBeenCalledTimes(1);
+      const savedUser: User = mockRepo.save.mock.calls[0][0];
+      expect(savedUser.profilePictureUrls).toEqual(MOCK_URLS);
+    });
+
+    it('throws NotFoundException when user does not exist', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(provider.execute('non-existent', MOCK_URLS)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('overwrites previously stored variant URLs on re-upload', async () => {
+      const oldUrls: ProfilePictureUrls = {
+        thumbnail: 'https://old.url/thumb',
+        avatar: 'https://old.url/avatar',
+        full: 'https://old.url/full',
+      };
+      const user = makeUser({ profilePictureUrls: oldUrls, profilePicture: oldUrls.avatar });
+      mockRepo.findOne.mockResolvedValue(user);
+      mockRepo.save.mockImplementation((u: User) => Promise.resolve(u));
+
+      const result = await provider.execute('user-1', MOCK_URLS);
+
+      expect(result.profilePictureUrls).toEqual(MOCK_URLS);
+      expect(result.profilePicture).toBe(MOCK_URLS.avatar);
+    });
+  });
+});

--- a/backend/src/users/providers/upload-profile-picture.provider.ts
+++ b/backend/src/users/providers/upload-profile-picture.provider.ts
@@ -2,17 +2,29 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../user.entity';
+import { ProfilePictureUrls } from '../../cloudinary/cloudinary.service';
 
 @Injectable()
 export class UploadProfilePictureProvider {
   constructor(@InjectRepository(User) private repo: Repository<User>) {}
 
-  async execute(id: string, profilePictureUrl: string): Promise<User> {
+  /**
+   * Persist multi-resolution profile picture URLs on the user record.
+   *
+   * Also writes the avatar URL to the legacy `profilePicture` column so that
+   * any existing code that reads `profilePicture` continues to work without
+   * modification (backward-compatible fallback).
+   */
+  async execute(id: string, urls: ProfilePictureUrls): Promise<User> {
     const user = await this.repo.findOne({ where: { id } });
     if (!user) {
       throw new NotFoundException('User not found');
     }
-    user.profilePicture = profilePictureUrl;
+
+    user.profilePictureUrls = urls;
+    // Backward-compat: expose the avatar variant via the old single-URL field
+    user.profilePicture = urls.avatar;
+
     return this.repo.save(user);
   }
 }

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,4 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, DeleteDateColumn } from 'typeorm';
+import { ProfilePictureUrls } from '../cloudinary/cloudinary.service';
 
 export enum UserRole {
   ADMIN = 'admin',
@@ -36,18 +37,34 @@ export class User {
   @Column({ type: 'timestamp', nullable: true })
   otpExpiry?: Date;
 
-   @Column({ default: false })
-   isVerified: boolean;
+  @Column({ default: false })
+  isVerified: boolean;
 
-   @Column({ default: true })
-   isActive: boolean;
+  @Column({ default: true })
+  isActive: boolean;
 
-   @Column({ nullable: true })
-   profilePicture?: string;
+  /**
+   * @deprecated Use `profilePictureUrls` instead.
+   * Kept for backward compatibility – returns the avatar variant URL when
+   * `profilePictureUrls` is set, otherwise the original single URL.
+   */
+  @Column({ nullable: true })
+  profilePicture?: string;
 
-   @CreateDateColumn()
-   createdAt!: Date;
+  /**
+   * Multi-resolution profile picture URLs stored as JSONB.
+   *
+   * Keys:
+   *  - thumbnail : 50×50  – use for comment avatars, notification icons
+   *  - avatar    : 200×200 – use for profile headers, user cards
+   *  - full      : 800×800 – use for profile detail pages
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  profilePictureUrls?: ProfilePictureUrls;
 
-   @DeleteDateColumn({ nullable: true })
-   deletedAt?: Date;
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt?: Date;
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -140,15 +140,67 @@ export class UsersController {
       limits: { fileSize: 5 * 1024 * 1024 },
     }),
   )
-  @ApiOperation({ summary: 'Upload profile picture' })
+  @ApiOperation({
+    summary: 'Upload profile picture',
+    description: `Uploads a profile picture and stores three resolution variants via Cloudinary transformations.
+
+**Variants stored**
+| Key | Dimensions | Use case |
+|-----|-----------|----------|
+| thumbnail | 50×50 | Comment avatars, notification icons |
+| avatar | 200×200 | Profile headers, user cards |
+| full | 800×800 | Profile detail pages |
+
+The upload applies EXIF orientation correction and face-detection auto-crop.
+
+**Backward compatibility**: The legacy \`profilePicture\` field continues to be populated with the \`avatar\` variant URL.`,
+  })
   @ApiParam({ name: 'id', type: String, description: 'User ID' })
-  @ApiResponse({ status: 200, description: 'Profile picture uploaded successfully' })
+  @ApiResponse({
+    status: 200,
+    description: 'Profile picture uploaded successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid' },
+        email: { type: 'string' },
+        profilePicture: {
+          type: 'string',
+          description: '(Deprecated) Avatar variant URL – kept for backward compatibility',
+          example: 'https://res.cloudinary.com/demo/image/upload/w_200,h_200,c_fill,g_face,q_auto,f_auto/hubassist/profile-pictures/abc123',
+        },
+        profilePictureUrls: {
+          type: 'object',
+          description: 'Multi-resolution variant URLs',
+          properties: {
+            thumbnail: {
+              type: 'string',
+              description: '50×50 thumbnail URL',
+              example: 'https://res.cloudinary.com/demo/image/upload/w_50,h_50,c_fill,g_face,q_auto,f_auto/hubassist/profile-pictures/abc123',
+            },
+            avatar: {
+              type: 'string',
+              description: '200×200 avatar URL',
+              example: 'https://res.cloudinary.com/demo/image/upload/w_200,h_200,c_fill,g_face,q_auto,f_auto/hubassist/profile-pictures/abc123',
+            },
+            full: {
+              type: 'string',
+              description: '800×800 full-size URL',
+              example: 'https://res.cloudinary.com/demo/image/upload/w_800,h_800,c_limit,g_auto,q_auto,f_auto/hubassist/profile-pictures/abc123',
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid file type or size' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   async uploadProfilePicture(
     @Param('id') id: string,
     @UploadedFile(FileValidationPipe) file: Express.Multer.File,
   ) {
-    const url = await this.cloudinaryService.uploadImage(file);
-    const result = await this.usersService.updateProfilePicture(id, url);
+    const urls = await this.cloudinaryService.uploadProfilePicture(file);
+    const result = await this.usersService.updateProfilePicture(id, urls);
     await this.cacheManager.del(this.userCacheKey(id));
     return result;
   }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -13,6 +13,7 @@ import { ForgotPasswordProvider } from './providers/forgot-password.provider';
 import { ResetPasswordProvider } from './providers/reset-password.provider';
 import { ChangePasswordProvider } from './providers/change-password.provider';
 import { User } from './user.entity';
+import { ProfilePictureUrls } from '../cloudinary/cloudinary.service';
 
 @Injectable()
 export class UsersService {
@@ -64,8 +65,8 @@ export class UsersService {
     return this.deleteUserProvider.execute(id);
   }
 
-  updateProfilePicture(id: string, profilePictureUrl: string) {
-    return this.uploadProfilePictureProvider.execute(id, profilePictureUrl);
+  updateProfilePicture(id: string, urls: ProfilePictureUrls) {
+    return this.uploadProfilePictureProvider.execute(id, urls);
   }
 
   validate(email: string, password: string) {


### PR DESCRIPTION
closes #290 
closes #291 


## Summary

Two backend features implemented on this branch.

---

### A — Admin Revenue Reporting API

**New endpoints (admin-only, JWT + RolesGuard):**

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/admin/reports/revenue` | Revenue aggregated by day/week/month |
| `GET` | `/api/v1/admin/reports/revenue/export` | Same data as streamed CSV |
| `GET` | `/api/v1/admin/reports/occupancy` | Workspace utilization percentages |

**Query params:** `startDate`, `endDate`, `workspaceType`, `status`, `groupBy` (day/week/month)

**Key details:**
- DB-level `GROUP BY` + `SUM` aggregation — no application-level iteration
- 5-minute cache TTL on all report endpoints
- CSV export streams with `Content-Disposition: attachment` header
- Two new CONCURRENTLY-built indexes: `idx_bookings_starttime_status` and `idx_bookings_starttime_workspaceid` — no table locks in production
- Full Swagger documentation on all filter params and response schemas
- Unit tests: revenue totals, date filter, CSV headers/row count, occupancy utilization

---

### B — Multi-resolution Profile Pictures

**Changes:**
- `CloudinaryService.uploadProfilePicture()` — single upload, three variant URLs via Cloudinary transformation strings
- Variants: thumbnail (50×50), avatar (200×200), full (800×800)
- EXIF orientation correction + face-detection auto-crop applied on upload
- `cloudinary.constants.ts` — centralised `PROFILE_PICTURE_VARIANTS` and `buildVariantUrl()`
- `User` entity: new `profilePictureUrls` JSONB column
- Legacy `profilePicture` column kept — populated with the avatar URL for backward compatibility
- Migration: `ADD COLUMN profilePictureUrls jsonb` + data migration of existing single-URL rows
- Full Swagger docs on all three variant URL keys in the user response schema
- Unit tests: URL generation per variant, upload → persistence flow, backward-compat fallback

---

## Files changed (18)

