### PR TITLE
feat(frontend): synchronize workspace and booking filter state with URL search parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 dist/
 .next/
+coverage/
 .env
 *.env.local
 

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/frontend/__tests__/lib/react-query/useForgotPassword.test.tsx
+++ b/frontend/__tests__/lib/react-query/useForgotPassword.test.tsx
@@ -293,7 +293,9 @@ describe("useForgotPassword", () => {
         result.current.mutate("user@example.com");
       });
 
-      expect(result.current.isPending).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(true);
+      });
 
       act(() => {
         resolveRequest!({ message: "Email sent" });
@@ -304,12 +306,22 @@ describe("useForgotPassword", () => {
       });
     });
 
-    it("should use correct mutation key", () => {
-      const { result } = renderHook(() => useForgotPassword(), {
-        wrapper: createWrapper(),
+    it("should register the mutation under the correct mutation key", () => {
+      const testQueryClient = createTestQueryClient();
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+      );
+
+      mockPost.mockReturnValueOnce(new Promise(() => {}));
+
+      const { result } = renderHook(() => useForgotPassword(), { wrapper });
+
+      act(() => {
+        result.current.mutate("user@example.com");
       });
 
-      expect(result.current.mutationKey).toEqual(["auth", "forgot-password"]);
+      const [mutation] = testQueryClient.getMutationCache().getAll();
+      expect(mutation?.options.mutationKey).toEqual(["auth", "forgot-password"]);
     });
 
     it("should reset error state on new mutation", async () => {

--- a/frontend/__tests__/lib/react-query/useLoginUser.test.tsx
+++ b/frontend/__tests__/lib/react-query/useLoginUser.test.tsx
@@ -230,7 +230,9 @@ describe("useLoginUser", () => {
         result.current.mutate({ email: "test@example.com", password: "pass" });
       });
 
-      expect(result.current.isPending).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(true);
+      });
 
       act(() => {
         resolveLogin!({ access_token: makeToken() });
@@ -241,12 +243,22 @@ describe("useLoginUser", () => {
       });
     });
 
-    it("should use correct mutation key", () => {
-      const { result } = renderHook(() => useLoginUser(), {
-        wrapper: createWrapper(),
+    it("should register the mutation under the correct mutation key", () => {
+      const testQueryClient = createTestQueryClient();
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+      );
+
+      mockPost.mockReturnValueOnce(new Promise(() => {}));
+
+      const { result } = renderHook(() => useLoginUser(), { wrapper });
+
+      act(() => {
+        result.current.mutate({ email: "test@example.com", password: "pass" });
       });
 
-      expect(result.current.mutationKey).toEqual(["auth", "login"]);
+      const [mutation] = testQueryClient.getMutationCache().getAll();
+      expect(mutation?.options.mutationKey).toEqual(["auth", "login"]);
     });
   });
 

--- a/frontend/__tests__/lib/react-query/useRegisterUser.test.tsx
+++ b/frontend/__tests__/lib/react-query/useRegisterUser.test.tsx
@@ -352,7 +352,9 @@ describe("useRegisterUser", () => {
         });
       });
 
-      expect(result.current.isPending).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(true);
+      });
 
       act(() => {
         resolveRegister!({ access_token: makeToken() });
@@ -363,12 +365,27 @@ describe("useRegisterUser", () => {
       });
     });
 
-    it("should use correct mutation key", () => {
-      const { result } = renderHook(() => useRegisterUser(), {
-        wrapper: createWrapper(),
+    it("should register the mutation under the correct mutation key", () => {
+      const testQueryClient = createTestQueryClient();
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+      );
+
+      mockPost.mockReturnValueOnce(new Promise(() => {}));
+
+      const { result } = renderHook(() => useRegisterUser(), { wrapper });
+
+      act(() => {
+        result.current.mutate({
+          firstname: "Jane",
+          lastname: "Smith",
+          email: "jane@example.com",
+          password: "pass",
+        });
       });
 
-      expect(result.current.mutationKey).toEqual(["auth", "register"]);
+      const [mutation] = testQueryClient.getMutationCache().getAll();
+      expect(mutation?.options.mutationKey).toEqual(["auth", "register"]);
     });
   });
 

--- a/frontend/src/app/dashboard/bookings/page.tsx
+++ b/frontend/src/app/dashboard/bookings/page.tsx
@@ -1,23 +1,37 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api, type BookingStatus } from "@/lib/apiClient";
 import { useAuthStore } from "@/lib/store/authStore";
 import { BookingCard } from "@/components/bookings/BookingCard";
+import { useFiltersWithUrl, type FilterSchema } from "@/hooks/useFiltersWithUrl";
+import { enumCodec } from "@/lib/filters/codecs";
 
-const TABS: { label: string; value: BookingStatus | "all" }[] = [
+type BookingTab = BookingStatus | "all";
+
+const TABS: { label: string; value: BookingTab }[] = [
   { label: "All", value: "all" },
   { label: "Pending", value: "pending" },
   { label: "Confirmed", value: "confirmed" },
   { label: "Cancelled", value: "cancelled" },
 ];
 
-export default function BookingsPage() {
+interface BookingsFilters {
+  tab: BookingTab;
+}
+
+const DEFAULT_BOOKINGS_FILTERS: BookingsFilters = { tab: "all" };
+
+const BOOKINGS_FILTERS_SCHEMA: FilterSchema<BookingsFilters> = {
+  tab: enumCodec(TABS.map((t) => t.value)),
+};
+
+function BookingsContent() {
   const token = useAuthStore((s) => s.token) ?? "";
   const user = useAuthStore((s) => s.user);
   const isAdmin = user?.role === "admin";
-  const [tab, setTab] = useState<BookingStatus | "all">("all");
+  const [{ tab }, setFilters] = useFiltersWithUrl(DEFAULT_BOOKINGS_FILTERS, BOOKINGS_FILTERS_SCHEMA);
 
   const { data: bookings = [], isLoading, isError } = useQuery({
     queryKey: ["bookings", tab],
@@ -34,7 +48,7 @@ export default function BookingsPage() {
         {TABS.map((t) => (
           <button
             key={t.value}
-            onClick={() => setTab(t.value)}
+            onClick={() => setFilters({ tab: t.value })}
             className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
               tab === t.value
                 ? "bg-[#1A1A1A] text-[#F3EBE2]"
@@ -66,5 +80,13 @@ export default function BookingsPage() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function BookingsPage() {
+  return (
+    <Suspense>
+      <BookingsContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/workspaces/page.tsx
+++ b/frontend/src/app/workspaces/page.tsx
@@ -1,12 +1,24 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense } from "react";
 import { useQuery } from "@tanstack/react-query";
-import type { Workspace, WorkspaceType, WorkspaceFilters } from "@/types/workspace";
+import type { Workspace, WorkspaceFilters, WorkspaceType } from "@/types/workspace";
 import { api } from "@/lib/apiClient";
 import { Button } from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
-import { Select } from "@/components/ui/Select";
+import { WorkspaceFiltersComponent } from "@/components/workspaces/WorkspaceFilters";
+import { useFiltersWithUrl, type FilterSchema } from "@/hooks/useFiltersWithUrl";
+import { booleanCodec, enumCodec, numberCodec } from "@/lib/filters/codecs";
+
+const WORKSPACE_TYPES: WorkspaceType[] = ["office", "meeting-room", "desk", "conference-room"];
+
+const DEFAULT_WORKSPACE_FILTERS: WorkspaceFilters = {};
+
+const WORKSPACE_FILTERS_SCHEMA: FilterSchema<WorkspaceFilters> = {
+  type: enumCodec(WORKSPACE_TYPES),
+  availability: booleanCodec(),
+  minPrice: numberCodec(),
+  maxPrice: numberCodec(),
+};
 
 interface WorkspacesResponse {
   workspaces: Workspace[];
@@ -66,65 +78,8 @@ function WorkspaceCard({ workspace }: { workspace: Workspace }) {
   );
 }
 
-function WorkspaceFilters({ filters, onFiltersChange }: {
-  filters: WorkspaceFilters;
-  onFiltersChange: (filters: WorkspaceFilters) => void;
-}) {
-  return (
-    <div className="bg-white p-4 rounded-lg shadow mb-6">
-      <div className="flex flex-wrap gap-4 items-end">
-        <div>
-          <label className="block text-sm font-medium mb-2">Type</label>
-          <Select
-            value={filters.type || ""}
-            onChange={(e) => onFiltersChange({ ...filters, type: e.target.value as WorkspaceType || undefined })}
-          >
-            <option value="">All Types</option>
-            <option value="office">Office</option>
-            <option value="meeting-room">Meeting Room</option>
-            <option value="desk">Desk</option>
-            <option value="conference-room">Conference Room</option>
-          </Select>
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-2">Availability</label>
-          <Select
-            value={filters.availability === undefined ? "" : filters.availability.toString()}
-            onChange={(e) => onFiltersChange({
-              ...filters,
-              availability: e.target.value === "" ? undefined : e.target.value === "true"
-            })}
-          >
-            <option value="">All</option>
-            <option value="true">Available</option>
-            <option value="false">Unavailable</option>
-          </Select>
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-2">Max Price ($/hour)</label>
-          <Input
-            type="number"
-            placeholder="Max price"
-            value={filters.maxPrice || ""}
-            onChange={(e) => onFiltersChange({
-              ...filters,
-              maxPrice: e.target.value ? parseInt(e.target.value) : undefined
-            })}
-          />
-        </div>
-        <Button
-          variant="outline"
-          onClick={() => onFiltersChange({})}
-        >
-          Clear Filters
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-export default function WorkspacesPage() {
-  const [filters, setFilters] = useState<WorkspaceFilters>({});
+function WorkspacesContent() {
+  const [filters, setFilters] = useFiltersWithUrl(DEFAULT_WORKSPACE_FILTERS, WORKSPACE_FILTERS_SCHEMA);
 
   const { data, isLoading, isError } = useQuery<WorkspacesResponse>({
     queryKey: ["workspaces", filters],
@@ -164,7 +119,7 @@ export default function WorkspacesPage() {
         <p className="text-gray-600">Find and book the perfect workspace for your needs</p>
       </div>
 
-      <WorkspaceFilters filters={filters} onFiltersChange={setFilters} />
+      <WorkspaceFiltersComponent filters={filters} onFiltersChange={setFilters} />
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {data?.workspaces?.length ? (
@@ -178,5 +133,13 @@ export default function WorkspacesPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function WorkspacesPage() {
+  return (
+    <Suspense>
+      <WorkspacesContent />
+    </Suspense>
   );
 }

--- a/frontend/src/components/dashboard/AnalyticsChart.tsx
+++ b/frontend/src/components/dashboard/AnalyticsChart.tsx
@@ -57,7 +57,8 @@ export function AnalyticsChart() {
             <Bar dataKey="count" fill="#1A1A1A" radius={[4, 4, 0, 0]} />
           </BarChart>
         </ResponsiveContainer>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/BookingRevenueChart.tsx
+++ b/frontend/src/components/dashboard/BookingRevenueChart.tsx
@@ -48,7 +48,8 @@ export function BookingRevenueChart() {
             <Area dataKey="revenue" stroke="#1A1A1A" strokeWidth={2} fill="url(#revenueGrad)" />
           </AreaChart>
         </ResponsiveContainer>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/WorkspaceUtilizationChart.tsx
+++ b/frontend/src/components/dashboard/WorkspaceUtilizationChart.tsx
@@ -47,7 +47,8 @@ export function WorkspaceUtilizationChart() {
             </Bar>
           </BarChart>
         </ResponsiveContainer>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/hooks/__tests__/useFiltersWithUrl.test.ts
+++ b/frontend/src/hooks/__tests__/useFiltersWithUrl.test.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from "@testing-library/react";
+import { useFiltersWithUrl, type FilterSchema } from "@/hooks/useFiltersWithUrl";
+import { booleanCodec, enumCodec } from "@/lib/filters/codecs";
+
+const replace = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => "/workspaces",
+  useSearchParams: () => mockSearchParams,
+}));
+
+interface TestFilters {
+  type?: "office" | "desk";
+  availability?: boolean;
+}
+
+const DEFAULT_FILTERS: TestFilters = {};
+
+const SCHEMA: FilterSchema<TestFilters> = {
+  type: enumCodec(["office", "desk"]),
+  availability: booleanCodec(),
+};
+
+describe("useFiltersWithUrl", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("initializes filters from valid URL search params", () => {
+    mockSearchParams = new URLSearchParams("type=desk&availability=true");
+
+    const { result } = renderHook(() => useFiltersWithUrl(DEFAULT_FILTERS, SCHEMA));
+
+    expect(result.current[0]).toEqual({ type: "desk", availability: true });
+  });
+
+  it("falls back to defaults when a URL param value is invalid", () => {
+    mockSearchParams = new URLSearchParams("type=InvalidType");
+
+    const { result } = renderHook(() => useFiltersWithUrl(DEFAULT_FILTERS, SCHEMA));
+
+    expect(result.current[0]).toEqual(DEFAULT_FILTERS);
+  });
+
+  it("restores filters after browser back/forward changes the search params", () => {
+    mockSearchParams = new URLSearchParams("type=desk");
+    const { result, rerender } = renderHook(() => useFiltersWithUrl(DEFAULT_FILTERS, SCHEMA));
+    expect(result.current[0]).toEqual({ type: "desk" });
+
+    mockSearchParams = new URLSearchParams("type=office");
+    rerender();
+    expect(result.current[0]).toEqual({ type: "office" });
+  });
+
+  it("updates the URL via router.replace (not push) when filters change", () => {
+    const { result } = renderHook(() => useFiltersWithUrl(DEFAULT_FILTERS, SCHEMA));
+
+    act(() => {
+      result.current[1]({ type: "office", availability: true });
+    });
+
+    expect(replace).toHaveBeenCalledWith("/workspaces?type=office&availability=true", { scroll: false });
+  });
+
+  it("omits params that match the defaults, keeping the URL clean", () => {
+    const { result } = renderHook(() => useFiltersWithUrl(DEFAULT_FILTERS, SCHEMA));
+
+    act(() => {
+      result.current[1]({});
+    });
+
+    expect(replace).toHaveBeenCalledWith("/workspaces", { scroll: false });
+  });
+});

--- a/frontend/src/hooks/useFiltersWithUrl.ts
+++ b/frontend/src/hooks/useFiltersWithUrl.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import type { FilterCodec } from "@/lib/filters/codecs";
+
+export type FilterSchema<F> = {
+  [K in keyof F]-?: FilterCodec<NonNullable<F[K]>>;
+};
+
+/**
+ * Synchronizes a filters object with URL search params using `router.replace`
+ * so filter changes don't pollute browser history. Invalid or missing params
+ * fall back to `defaultFilters`.
+ */
+export function useFiltersWithUrl<F extends object>(
+  defaultFilters: F,
+  schema: FilterSchema<F>
+) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const filters = useMemo(() => {
+    const result = { ...defaultFilters };
+    (Object.keys(schema) as (keyof F)[]).forEach((key) => {
+      const raw = searchParams.get(key as string);
+      if (raw === null || raw === "") return;
+      const parsed = schema[key].parse(raw);
+      if (parsed !== undefined) {
+        result[key] = parsed as F[typeof key];
+      }
+    });
+    return result;
+  }, [searchParams, schema, defaultFilters]);
+
+  const setFilters = useCallback(
+    (next: F) => {
+      const params = new URLSearchParams();
+      (Object.keys(schema) as (keyof F)[]).forEach((key) => {
+        const value = next[key];
+        const isDefault = value === undefined || value === defaultFilters[key];
+        if (!isDefault) {
+          params.set(key as string, schema[key].serialize(value as NonNullable<F[typeof key]>));
+        }
+      });
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    },
+    [defaultFilters, pathname, router, schema]
+  );
+
+  return [filters, setFilters] as const;
+}

--- a/frontend/src/hooks/useNewsletterForm.ts
+++ b/frontend/src/hooks/useNewsletterForm.ts
@@ -2,7 +2,7 @@
 
 import { FormEvent, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { useToast } from "@/components/ui/ToastProvider";
 
 export interface UseNewsletterFormResult {
@@ -27,7 +27,7 @@ export function useNewsletterForm(): UseNewsletterFormResult {
       showToast("success", "Successfully subscribed to the newsletter!");
       setEmail("");
     },
-    onError: (error: any) => {
+    onError: (error: AxiosError) => {
       if (error.response?.status === 409) {
         showToast("error", "This email is already subscribed.");
       } else {

--- a/frontend/src/lib/filters/__tests__/codecs.test.ts
+++ b/frontend/src/lib/filters/__tests__/codecs.test.ts
@@ -1,0 +1,42 @@
+import { booleanCodec, enumCodec, numberCodec } from "@/lib/filters/codecs";
+
+describe("enumCodec", () => {
+  const codec = enumCodec(["office", "desk"] as const);
+
+  it("parses values in the allowed list", () => {
+    expect(codec.parse("desk")).toBe("desk");
+  });
+
+  it("returns undefined for values outside the allowed list", () => {
+    expect(codec.parse("InvalidType")).toBeUndefined();
+  });
+
+  it("serializes back to the raw string", () => {
+    expect(codec.serialize("office")).toBe("office");
+  });
+});
+
+describe("booleanCodec", () => {
+  const codec = booleanCodec();
+
+  it("parses 'true' and 'false'", () => {
+    expect(codec.parse("true")).toBe(true);
+    expect(codec.parse("false")).toBe(false);
+  });
+
+  it("returns undefined for anything else", () => {
+    expect(codec.parse("yes")).toBeUndefined();
+  });
+});
+
+describe("numberCodec", () => {
+  const codec = numberCodec();
+
+  it("parses finite numeric strings", () => {
+    expect(codec.parse("42")).toBe(42);
+  });
+
+  it("returns undefined for non-numeric strings", () => {
+    expect(codec.parse("abc")).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/filters/codecs.ts
+++ b/frontend/src/lib/filters/codecs.ts
@@ -1,0 +1,32 @@
+export interface FilterCodec<T> {
+  parse: (raw: string) => T | undefined;
+  serialize: (value: T) => string;
+}
+
+export function enumCodec<T extends string>(allowed: readonly T[]): FilterCodec<T> {
+  return {
+    parse: (raw) => (allowed.includes(raw as T) ? (raw as T) : undefined),
+    serialize: (value) => value,
+  };
+}
+
+export function booleanCodec(): FilterCodec<boolean> {
+  return {
+    parse: (raw) => {
+      if (raw === "true") return true;
+      if (raw === "false") return false;
+      return undefined;
+    },
+    serialize: (value) => String(value),
+  };
+}
+
+export function numberCodec(): FilterCodec<number> {
+  return {
+    parse: (raw) => {
+      const value = Number(raw);
+      return Number.isFinite(value) ? value : undefined;
+    },
+    serialize: (value) => String(value),
+  };
+}


### PR DESCRIPTION
## Summary
- Closes #344. Adds a `useFiltersWithUrl(defaultFilters, schema)` hook wrapping `next/navigation`'s `useSearchParams`/`useRouter` that encodes filters into the URL via `router.replace` (no history pollution), with type-safe codecs (`enumCodec`/`booleanCodec`/`numberCodec`) that fall back to defaults on invalid values.
- Wires the hook into `/workspaces` (type, availability, min/max price) and `/dashboard/bookings` (status tab), so filters survive refresh and respond correctly to browser back/forward navigation.
- Removed a dead, duplicate filter component in `app/workspaces/page.tsx` that shadowed the shared `WorkspaceFiltersComponent`.

## Also fixed (pre-existing, was blocking CI entirely)
While verifying checks locally, found CI has been failing repo-wide on every push for weeks, before any of my changes:
- `npm ci` failing on a `recharts`/`react@19` peer-dependency conflict → added `frontend/.npmrc` with `legacy-peer-deps=true`.
- 3 dashboard chart components (`AnalyticsChart`, `BookingRevenueChart`, `WorkspaceUtilizationChart`) had a missing IIFE closing `})()`, which is a real syntax error that broke `next build` outright.
- A `@typescript-eslint/no-explicit-any` lint error in `useNewsletterForm.ts`.
- 3 auth mutation tests (`useLoginUser`/`useForgotPassword`/`useRegisterUser`) asserted a `mutationKey` property that doesn't exist on `useMutation`'s return value (always `undefined`), and an `isPending` check with a flaky synchronous-timing assumption. Rewrote both to assert real behavior (mutation cache key, `waitFor`-based pending check).

closes #344 

## Test plan
- [x] `npm run lint` — no errors (pre-existing `<img>` warnings only)
- [x] `npm run build` — succeeds, `/workspaces` and `/dashboard/bookings` prerender statically
- [x] `npx jest` — 15/15 suites, 106/106 tests passing
- [x] New unit tests: URL → filters decoding (valid + invalid values), filters → URL encoding via `router.replace`, restoring filters after simulated back/forward navigation