### PR TITLE
feat(frontend): optimistic UI updates for booking mutations with rollback

### DIFF
--- a/frontend/__tests__/lib/react-query/useCancelBooking.test.tsx
+++ b/frontend/__tests__/lib/react-query/useCancelBooking.test.tsx
@@ -1,0 +1,258 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useCancelBooking } from "@/lib/react-query/hooks/bookings/useCancelBooking";
+import * as apiClient from "@/lib/apiClient";
+import type { Booking } from "@/lib/apiClient";
+import React from "react";
+
+jest.mock("@/lib/apiClient");
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const makeBooking = (overrides?: Partial<Booking>): Booking => ({
+  id: "booking-1",
+  workspaceName: "Hot Desk A",
+  date: "2026-07-01",
+  startTime: "09:00",
+  endTime: "17:00",
+  amount: 50,
+  status: "pending",
+  ...overrides,
+});
+
+const createWrapper = (queryClient: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+describe("useCancelBooking", () => {
+  let mockCancelBooking: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCancelBooking = jest.fn();
+    (apiClient.api as any) = {
+      ...(apiClient.api as any),
+      cancelBooking: mockCancelBooking,
+    };
+  });
+
+  describe("optimistic update", () => {
+    it("sets booking status to cancelled before API call completes", async () => {
+      const booking = makeBooking();
+      let resolveCancel!: (value: Booking) => void;
+      mockCancelBooking.mockReturnValueOnce(
+        new Promise<Booking>((resolve) => { resolveCancel = resolve; })
+      );
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+      queryClient.setQueryData(["bookings", "all"], [booking]);
+
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isPending).toBe(true));
+
+      const optimisticBooking = queryClient.getQueryData<Booking>(["booking", booking.id]);
+      expect(optimisticBooking?.status).toBe("cancelled");
+
+      const optimisticList = queryClient.getQueryData<Booking[]>(["bookings", "all"]);
+      expect(optimisticList?.[0].status).toBe("cancelled");
+
+      resolveCancel(makeBooking({ status: "cancelled" }));
+    });
+
+    it("registers mutation under the correct mutation key", async () => {
+      mockCancelBooking.mockReturnValueOnce(new Promise(() => {}));
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate("booking-1");
+      });
+
+      const [mutation] = queryClient.getMutationCache().getAll();
+      expect(mutation?.options.mutationKey).toEqual(["bookings", "cancel"]);
+    });
+
+    it("applies optimistic update on a confirmed booking being cancelled", async () => {
+      const booking = makeBooking({ status: "confirmed" });
+      let resolveCancel!: (value: Booking) => void;
+      mockCancelBooking.mockReturnValueOnce(
+        new Promise<Booking>((resolve) => { resolveCancel = resolve; })
+      );
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isPending).toBe(true));
+
+      const optimisticBooking = queryClient.getQueryData<Booking>(["booking", booking.id]);
+      expect(optimisticBooking?.status).toBe("cancelled");
+
+      resolveCancel(makeBooking({ status: "cancelled" }));
+    });
+  });
+
+  describe("onError rollback", () => {
+    it("restores booking to previous pending status on API failure", async () => {
+      const booking = makeBooking();
+      mockCancelBooking.mockRejectedValueOnce(new Error("Server error"));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+      queryClient.setQueryData(["bookings", "all"], [booking]);
+
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      const rolledBackBooking = queryClient.getQueryData<Booking>(["booking", booking.id]);
+      expect(rolledBackBooking?.status).toBe("pending");
+
+      const rolledBackList = queryClient.getQueryData<Booking[]>(["bookings", "all"]);
+      expect(rolledBackList?.[0].status).toBe("pending");
+    });
+
+    it("restores a confirmed booking to confirmed on API failure", async () => {
+      const booking = makeBooking({ status: "confirmed" });
+      mockCancelBooking.mockRejectedValueOnce(new Error("Server error"));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      const rolledBackBooking = queryClient.getQueryData<Booking>(["booking", booking.id]);
+      expect(rolledBackBooking?.status).toBe("confirmed");
+    });
+
+    it("restores all cached booking lists on error", async () => {
+      const booking = makeBooking();
+      mockCancelBooking.mockRejectedValueOnce(new Error("Network error"));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["bookings", "all"], [booking]);
+      queryClient.setQueryData(["bookings", "pending"], [booking]);
+
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(queryClient.getQueryData<Booking[]>(["bookings", "all"])?.[0].status).toBe("pending");
+      expect(queryClient.getQueryData<Booking[]>(["bookings", "pending"])?.[0].status).toBe("pending");
+    });
+  });
+
+  describe("onSettled", () => {
+    it("invalidates bookings queries after successful mutation", async () => {
+      const booking = makeBooking();
+      mockCancelBooking.mockResolvedValueOnce(makeBooking({ status: "cancelled" }));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+      const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["bookings"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["booking", booking.id] });
+    });
+
+    it("invalidates bookings queries even after a failed mutation", async () => {
+      const booking = makeBooking();
+      mockCancelBooking.mockRejectedValueOnce(new Error("Server error"));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+      const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["bookings"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["booking", booking.id] });
+    });
+  });
+
+  describe("race conditions", () => {
+    it("handles rapid successive mutations without corrupting the cache", async () => {
+      const bookingA = makeBooking({ id: "a" });
+      const bookingB = makeBooking({ id: "b", status: "confirmed" });
+      mockCancelBooking.mockResolvedValue(makeBooking({ status: "cancelled" }));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["bookings", "all"], [bookingA, bookingB]);
+
+      const { result } = renderHook(() => useCancelBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate("a");
+        result.current.mutate("b");
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockCancelBooking).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/__tests__/lib/react-query/useConfirmBooking.test.tsx
+++ b/frontend/__tests__/lib/react-query/useConfirmBooking.test.tsx
@@ -1,0 +1,211 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useConfirmBooking } from "@/lib/react-query/hooks/bookings/useConfirmBooking";
+import * as apiClient from "@/lib/apiClient";
+import type { Booking } from "@/lib/apiClient";
+import React from "react";
+
+jest.mock("@/lib/apiClient");
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const makeBooking = (overrides?: Partial<Booking>): Booking => ({
+  id: "booking-1",
+  workspaceName: "Hot Desk A",
+  date: "2026-07-01",
+  startTime: "09:00",
+  endTime: "17:00",
+  amount: 50,
+  status: "pending",
+  ...overrides,
+});
+
+const createWrapper = (queryClient: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+describe("useConfirmBooking", () => {
+  let mockConfirmBooking: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfirmBooking = jest.fn();
+    (apiClient.api as any) = {
+      ...(apiClient.api as any),
+      confirmBooking: mockConfirmBooking,
+    };
+  });
+
+  describe("optimistic update", () => {
+    it("sets booking status to confirmed before API call completes", async () => {
+      const booking = makeBooking();
+      let resolveConfirm!: (value: Booking) => void;
+      mockConfirmBooking.mockReturnValueOnce(
+        new Promise<Booking>((resolve) => { resolveConfirm = resolve; })
+      );
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+      queryClient.setQueryData(["bookings", "all"], [booking]);
+
+      const { result } = renderHook(() => useConfirmBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isPending).toBe(true));
+
+      const optimisticBooking = queryClient.getQueryData<Booking>(["booking", booking.id]);
+      expect(optimisticBooking?.status).toBe("confirmed");
+
+      const optimisticList = queryClient.getQueryData<Booking[]>(["bookings", "all"]);
+      expect(optimisticList?.[0].status).toBe("confirmed");
+
+      resolveConfirm(makeBooking({ status: "confirmed" }));
+    });
+
+    it("registers mutation under the correct mutation key", async () => {
+      mockConfirmBooking.mockReturnValueOnce(new Promise(() => {}));
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useConfirmBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate("booking-1");
+      });
+
+      const [mutation] = queryClient.getMutationCache().getAll();
+      expect(mutation?.options.mutationKey).toEqual(["bookings", "confirm"]);
+    });
+  });
+
+  describe("onError rollback", () => {
+    it("restores booking to previous pending status on API failure", async () => {
+      const booking = makeBooking();
+      mockConfirmBooking.mockRejectedValueOnce(new Error("Server error"));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+      queryClient.setQueryData(["bookings", "all"], [booking]);
+
+      const { result } = renderHook(() => useConfirmBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      const rolledBackBooking = queryClient.getQueryData<Booking>(["booking", booking.id]);
+      expect(rolledBackBooking?.status).toBe("pending");
+
+      const rolledBackList = queryClient.getQueryData<Booking[]>(["bookings", "all"]);
+      expect(rolledBackList?.[0].status).toBe("pending");
+    });
+
+    it("restores all cached booking lists on error", async () => {
+      const booking = makeBooking();
+      mockConfirmBooking.mockRejectedValueOnce(new Error("Network error"));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["bookings", "all"], [booking]);
+      queryClient.setQueryData(["bookings", "pending"], [booking]);
+
+      const { result } = renderHook(() => useConfirmBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(queryClient.getQueryData<Booking[]>(["bookings", "all"])?.[0].status).toBe("pending");
+      expect(queryClient.getQueryData<Booking[]>(["bookings", "pending"])?.[0].status).toBe("pending");
+    });
+  });
+
+  describe("onSettled", () => {
+    it("invalidates bookings queries after successful mutation", async () => {
+      const booking = makeBooking();
+      mockConfirmBooking.mockResolvedValueOnce(makeBooking({ status: "confirmed" }));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+      const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useConfirmBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["bookings"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["booking", booking.id] });
+    });
+
+    it("invalidates bookings queries even after a failed mutation", async () => {
+      const booking = makeBooking();
+      mockConfirmBooking.mockRejectedValueOnce(new Error("Server error"));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["booking", booking.id], booking);
+      const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useConfirmBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(booking.id);
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["bookings"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["booking", booking.id] });
+    });
+  });
+
+  describe("race conditions", () => {
+    it("handles rapid successive mutations without corrupting the cache", async () => {
+      const bookingA = makeBooking({ id: "a" });
+      const bookingB = makeBooking({ id: "b" });
+      mockConfirmBooking.mockResolvedValue(makeBooking({ status: "confirmed" }));
+
+      const queryClient = createTestQueryClient();
+      queryClient.setQueryData(["bookings", "all"], [bookingA, bookingB]);
+
+      const { result } = renderHook(() => useConfirmBooking(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate("a");
+        result.current.mutate("b");
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockConfirmBooking).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/components/bookings/BookingActions.tsx
+++ b/frontend/src/components/bookings/BookingActions.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { api, type Booking } from "@/lib/apiClient";
+import { useConfirmBooking } from "@/lib/react-query/hooks/bookings/useConfirmBooking";
+import { useCancelBooking } from "@/lib/react-query/hooks/bookings/useCancelBooking";
 import { Button } from "@/components/ui/Button";
+import type { Booking } from "@/lib/apiClient";
 
 interface Props {
   booking: Booking;
@@ -10,47 +11,42 @@ interface Props {
 }
 
 export function BookingActions({ booking, isAdmin }: Props) {
-  const qc = useQueryClient();
+  const confirm = useConfirmBooking();
+  const cancel = useCancelBooking();
 
-  const invalidate = () => {
-    qc.invalidateQueries({ queryKey: ["bookings"] });
-    qc.invalidateQueries({ queryKey: ["booking", booking.id] });
-  };
-
-  const confirm = useMutation({
-    mutationFn: () => api.confirmBooking(booking.id),
-    onSuccess: invalidate,
-  });
-
-  const cancel = useMutation({
-    mutationFn: () => api.cancelBooking(booking.id),
-    onSuccess: invalidate,
-  });
-
+  const isMutating = confirm.isPending || cancel.isPending;
   const isPending = booking.status === "pending";
   const isCancellable = booking.status === "pending" || booking.status === "confirmed";
 
   if (!isAdmin && !isCancellable) return null;
 
   return (
-    <div className="flex gap-2 flex-wrap">
-      {isAdmin && isPending && (
-        <Button
-          variant="primary"
-          onClick={() => confirm.mutate()}
-          disabled={confirm.isPending}
-        >
-          {confirm.isPending ? "Confirming…" : "Confirm"}
-        </Button>
-      )}
-      {isCancellable && (
-        <Button
-          variant="ghost"
-          onClick={() => cancel.mutate()}
-          disabled={cancel.isPending}
-        >
-          {cancel.isPending ? "Cancelling…" : "Cancel"}
-        </Button>
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-2 flex-wrap">
+        {isAdmin && isPending && (
+          <Button
+            variant="primary"
+            onClick={() => confirm.mutate(booking.id)}
+            disabled={isMutating}
+          >
+            {confirm.isPending ? "Confirming…" : "Confirm"}
+          </Button>
+        )}
+        {isCancellable && (
+          <Button
+            variant="ghost"
+            onClick={() => cancel.mutate(booking.id)}
+            disabled={isMutating}
+          >
+            {cancel.isPending ? "Cancelling…" : "Cancel"}
+          </Button>
+        )}
+      </div>
+      {isMutating && (
+        <p className="text-xs text-[#6B6B6B] flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full bg-[#6B6B6B] animate-pulse" />
+          Syncing with server…
+        </p>
       )}
     </div>
   );

--- a/frontend/src/lib/react-query/hooks/bookings/useCancelBooking.ts
+++ b/frontend/src/lib/react-query/hooks/bookings/useCancelBooking.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api, type Booking } from "@/lib/apiClient";
+import { mutationKeys } from "@/lib/react-query/keys/mutationKeys";
+
+export function useCancelBooking() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: mutationKeys.bookings.cancel,
+    mutationFn: (id: string) => api.cancelBooking(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: ["bookings"] });
+      await queryClient.cancelQueries({ queryKey: ["booking", id] });
+
+      const previousBookingsList = queryClient.getQueriesData<Booking[]>({ queryKey: ["bookings"] });
+      const previousBooking = queryClient.getQueryData<Booking>(["booking", id]);
+
+      queryClient.setQueriesData<Booking[]>({ queryKey: ["bookings"] }, (old) =>
+        old?.map((b) => (b.id === id ? { ...b, status: "cancelled" } : b)) ?? old
+      );
+      queryClient.setQueryData<Booking>(["booking", id], (old) =>
+        old ? { ...old, status: "cancelled" } : old
+      );
+
+      return { previousBookingsList, previousBooking };
+    },
+    onError: (_, id, context) => {
+      context?.previousBookingsList.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+      if (context?.previousBooking) {
+        queryClient.setQueryData(["booking", id], context.previousBooking);
+      }
+    },
+    onSettled: (_, __, id) => {
+      queryClient.invalidateQueries({ queryKey: ["bookings"] });
+      queryClient.invalidateQueries({ queryKey: ["booking", id] });
+    },
+  });
+}

--- a/frontend/src/lib/react-query/hooks/bookings/useConfirmBooking.ts
+++ b/frontend/src/lib/react-query/hooks/bookings/useConfirmBooking.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api, type Booking } from "@/lib/apiClient";
+import { mutationKeys } from "@/lib/react-query/keys/mutationKeys";
+
+export function useConfirmBooking() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: mutationKeys.bookings.confirm,
+    mutationFn: (id: string) => api.confirmBooking(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: ["bookings"] });
+      await queryClient.cancelQueries({ queryKey: ["booking", id] });
+
+      const previousBookingsList = queryClient.getQueriesData<Booking[]>({ queryKey: ["bookings"] });
+      const previousBooking = queryClient.getQueryData<Booking>(["booking", id]);
+
+      queryClient.setQueriesData<Booking[]>({ queryKey: ["bookings"] }, (old) =>
+        old?.map((b) => (b.id === id ? { ...b, status: "confirmed" } : b)) ?? old
+      );
+      queryClient.setQueryData<Booking>(["booking", id], (old) =>
+        old ? { ...old, status: "confirmed" } : old
+      );
+
+      return { previousBookingsList, previousBooking };
+    },
+    onError: (_, id, context) => {
+      context?.previousBookingsList.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+      if (context?.previousBooking) {
+        queryClient.setQueryData(["booking", id], context.previousBooking);
+      }
+    },
+    onSettled: (_, __, id) => {
+      queryClient.invalidateQueries({ queryKey: ["bookings"] });
+      queryClient.invalidateQueries({ queryKey: ["booking", id] });
+    },
+  });
+}

--- a/frontend/src/lib/react-query/hooks/index.ts
+++ b/frontend/src/lib/react-query/hooks/index.ts
@@ -1,3 +1,5 @@
 export { useLoginUser } from "./auth/useLoginUser";
 export { useRegisterUser } from "./auth/useRegisterUser";
 export { useForgotPassword } from "./auth/useForgotPassword";
+export { useConfirmBooking } from "./bookings/useConfirmBooking";
+export { useCancelBooking } from "./bookings/useCancelBooking";

--- a/frontend/src/lib/react-query/keys/mutationKeys.ts
+++ b/frontend/src/lib/react-query/keys/mutationKeys.ts
@@ -4,4 +4,8 @@ export const mutationKeys = {
     register: ['auth', 'register'] as const,
     forgotPassword: ['auth', 'forgot-password'] as const,
   },
+  bookings: {
+    confirm: ['bookings', 'confirm'] as const,
+    cancel: ['bookings', 'cancel'] as const,
+  },
 } as const;


### PR DESCRIPTION
## Summary

- Extract `useConfirmBooking` and `useCancelBooking` hooks from inline `BookingActions` mutations, adding `onMutate` for instant optimistic cache updates across all `["bookings", *]` and `["booking", id]` query keys
- Implement `onError` rollback that restores exact pre-mutation cache state using snapshotted `getQueriesData` / `getQueryData` results
- Call `queryClient.invalidateQueries` in `onSettled` to sync both list and detail caches with server truth regardless of outcome
- Add a "Syncing with server…" animated indicator in `BookingActions` to visually distinguish the optimistic state from a server-confirmed state; both action buttons are disabled while any mutation is in flight

## Test plan

- [ ] `useConfirmBooking` — `onMutate` sets `status: "confirmed"` in both list and detail caches before the API resolves
- [ ] `useConfirmBooking` — `onError` restores all affected caches to their pre-mutation state (`status: "pending"`)
- [ ] `useConfirmBooking` — `onSettled` invalidates `["bookings"]` and `["booking", id]` on success and on failure
- [ ] `useCancelBooking` — same three scenarios plus rollback from `confirmed → confirmed` on error
- [ ] Rapid successive mutations on different bookings do not corrupt the query cache
- [ ] All 122 existing tests continue to pass (`npm test`)

closes #343 