### PR TITLE
feat(frontend): add notification center with localStorage-persisted read/unread state management

### DIFF
--- a/frontend/src/components/dashboard/DashboardLayout.tsx
+++ b/frontend/src/components/dashboard/DashboardLayout.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
 import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
+import { Header } from "@/components/dashboard/Header";
 
 export function DashboardLayout({ children }: Readonly<{ children: ReactNode }>) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -26,17 +27,7 @@ export function DashboardLayout({ children }: Readonly<{ children: ReactNode }>)
 
       {/* Main */}
       <div className="flex flex-1 flex-col min-w-0">
-        {/* Mobile topbar */}
-        <header className="flex items-center gap-3 border-b border-[#D7CFC6] bg-[#F3EBE2] px-4 py-3 lg:hidden">
-          <button
-            onClick={() => setSidebarOpen(true)}
-            aria-label="Open menu"
-            className="rounded-lg p-1.5 text-[#6B6B6B] hover:bg-[#EDE2D6] hover:text-[#1A1A1A]"
-          >
-            ☰
-          </button>
-          <span className="text-base font-semibold text-[#1A1A1A]">Hubassist</span>
-        </header>
+        <Header onOpenMenu={() => setSidebarOpen(true)} />
 
         <main className="flex-1 p-6">{children}</main>
       </div>

--- a/frontend/src/components/dashboard/Header.tsx
+++ b/frontend/src/components/dashboard/Header.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState } from 'react';
+import { Bell } from 'lucide-react';
+import { useNotifications } from '@/hooks/useNotifications';
+import { NotificationCenter } from './NotificationCenter';
+
+export function Header({ onOpenMenu }: { onOpenMenu: () => void }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { notifications, readIds, unreadCount, markAsRead, markAllAsRead } = useNotifications();
+
+  return (
+    <header className="flex items-center justify-between gap-3 border-b border-[#D7CFC6] bg-[#F3EBE2] px-4 py-3">
+      <div className="flex items-center gap-3">
+        <button onClick={onOpenMenu} aria-label="Open menu" className="rounded-lg p-1.5 text-[#6B6B6B] hover:bg-[#EDE2D6] hover:text-[#1A1A1A] lg:hidden">☰</button>
+        <span className="text-base font-semibold text-[#1A1A1A]">Hubassist</span>
+      </div>
+      <div className="relative">
+        <button type="button" onClick={() => setIsOpen((open) => !open)} aria-label="Notifications" aria-expanded={isOpen} className="relative rounded-lg p-2 text-[#6B6B6B] hover:bg-[#EDE2D6] hover:text-[#1A1A1A]">
+          <Bell size={20} aria-hidden />
+          {unreadCount > 0 && <span aria-label={`${unreadCount} unread notifications`} className="absolute -right-1 -top-1 flex min-w-5 h-5 items-center justify-center rounded-full bg-[#B8612A] px-1 text-[11px] font-semibold text-white">{unreadCount > 99 ? '99+' : unreadCount}</span>}
+        </button>
+        {isOpen && <NotificationCenter notifications={notifications} readIds={readIds} onMarkAsRead={markAsRead} onMarkAllAsRead={markAllAsRead} onDismiss={() => setIsOpen(false)} />}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/dashboard/NotificationCenter.tsx
+++ b/frontend/src/components/dashboard/NotificationCenter.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Notification } from '@/hooks/useNotifications';
+
+interface NotificationCenterProps {
+  notifications: Notification[];
+  readIds: Set<string>;
+  onMarkAsRead: (id: string) => void;
+  onMarkAllAsRead: () => void;
+  onDismiss: () => void;
+}
+
+export function notificationContextPath(notification: Notification): string {
+  if (notification.contextPath) return notification.contextPath;
+  if (notification.type === 'booking' || /booking/i.test(notification.description)) return '/dashboard/bookings';
+  if (notification.type === 'attendance' || /attendance|clock.?in|clock.?out/i.test(notification.description)) return '/dashboard/attendance';
+  return '/profile';
+}
+
+function timeAgo(iso: string): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 1000));
+  if (seconds < 60) return 'Just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86400)}d ago`;
+}
+
+export function NotificationCenter({ notifications, readIds, onMarkAsRead, onMarkAllAsRead, onDismiss }: NotificationCenterProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const onPointerDown = (event: MouseEvent) => {
+      if (!panelRef.current?.contains(event.target as Node)) onDismiss();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onDismiss();
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onDismiss]);
+
+  return (
+    <div ref={panelRef} role="dialog" aria-label="Notification center" className="absolute right-0 top-full z-50 mt-2 w-[min(24rem,calc(100vw-2rem))] overflow-hidden rounded-2xl border border-[#D7CFC6] bg-[#FDF9F5] shadow-xl">
+      <div className="flex items-center justify-between border-b border-[#EDE2D6] px-4 py-3">
+        <h2 className="font-semibold text-[#1A1A1A]">Notifications</h2>
+        <button type="button" onClick={onMarkAllAsRead} disabled={!notifications.some((item) => !readIds.has(item.id))} className="text-xs font-medium text-[#7A4E2D] disabled:cursor-not-allowed disabled:opacity-50">
+          Mark all read
+        </button>
+      </div>
+      {notifications.length === 0 ? (
+        <p className="px-4 py-10 text-center text-sm text-[#6B6B6B]">You&apos;re all caught up.</p>
+      ) : (
+        <ul className="max-h-[24rem] overflow-y-auto py-1">
+          {notifications.map((notification) => {
+            const unread = !readIds.has(notification.id);
+            return <li key={notification.id}>
+              <button type="button" onClick={() => { onMarkAsRead(notification.id); router.push(notificationContextPath(notification)); onDismiss(); }} className={`flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-[#F3EBE2] ${unread ? 'bg-[#F8EFE5]' : ''}`}>
+                <span aria-hidden className="mt-0.5 text-base">{notification.icon ?? '•'}</span>
+                <span className="min-w-0 flex-1"><span className="block text-sm text-[#1A1A1A]">{notification.description}</span><span className="mt-1 block text-xs text-[#6B6B6B]">{timeAgo(notification.timestamp)}</span></span>
+                {unread && <span aria-label="Unread" className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-[#B8612A]" />}
+              </button>
+            </li>;
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/__tests__/NotificationCenter.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/NotificationCenter.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { NotificationCenter } from '@/components/dashboard/NotificationCenter';
+
+const push = jest.fn();
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push }) }));
+
+describe('NotificationCenter', () => {
+  const props = {
+    notifications: [{ id: 'booking-1', type: 'booking', description: 'Booking confirmed', timestamp: new Date().toISOString() }],
+    readIds: new Set<string>(),
+    onMarkAsRead: jest.fn(),
+    onMarkAllAsRead: jest.fn(),
+    onDismiss: jest.fn(),
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('marks a notification read and navigates to its context page when clicked', () => {
+    render(<NotificationCenter {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /booking confirmed/i }));
+
+    expect(props.onMarkAsRead).toHaveBeenCalledWith('booking-1');
+    expect(push).toHaveBeenCalledWith('/dashboard/bookings');
+    expect(props.onDismiss).toHaveBeenCalled();
+  });
+
+  it('dismisses when Escape is pressed or the user clicks outside', () => {
+    render(<><NotificationCenter {...props} /><button type="button">Outside</button></>);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Outside' }));
+    expect(props.onDismiss).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/hooks/__tests__/useNotifications.test.tsx
+++ b/frontend/src/hooks/__tests__/useNotifications.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { get } from '@/lib/apiClient';
+import { NOTIFICATION_READ_STORAGE_KEY, useNotifications } from '@/hooks/useNotifications';
+
+jest.mock('@/lib/apiClient', () => ({ get: jest.fn() }));
+
+const mockedGet = get as jest.MockedFunction<typeof get>;
+const activities = [
+  { id: 'booking-1', description: 'Booking confirmed', timestamp: '2026-07-20T09:00:00Z' },
+  { id: 'attendance-1', description: 'Attendance anomaly', timestamp: '2026-07-20T10:00:00Z' },
+];
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockedGet.mockResolvedValue(activities);
+  });
+
+  it('derives unreadCount after merging activity with persisted read IDs', async () => {
+    window.localStorage.setItem(NOTIFICATION_READ_STORAGE_KEY, JSON.stringify({ 'booking-1': Date.now() }));
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.unreadCount).toBe(1);
+  });
+
+  it('persists a notification ID when it is marked as read', async () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    act(() => result.current.markAsRead('attendance-1'));
+
+    expect(JSON.parse(window.localStorage.getItem(NOTIFICATION_READ_STORAGE_KEY) ?? '{}')).toEqual(expect.objectContaining({ 'attendance-1': expect.any(Number) }));
+    expect(result.current.unreadCount).toBe(1);
+  });
+});

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,14 +1,99 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { io, Socket } from 'socket.io-client';
 import { useAuthStore } from '@/lib/store/authStore';
 import { useToast } from '@/components/ui/ToastProvider';
 import { env } from '@/utils/env';
+import { get } from '@/lib/apiClient';
 
 const WS_URL = env.apiUrl.replace('/api', '');
+export const NOTIFICATION_READ_STORAGE_KEY = 'hubassist:read-notification-ids';
+export const READ_NOTIFICATION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
+export interface Notification {
+  id: string;
+  icon?: string;
+  description: string;
+  timestamp: string;
+  type?: 'booking' | 'membership' | 'attendance' | string;
+  contextPath?: string;
+}
+
+type ReadNotificationStore = Record<string, number>;
+
+function readStoredNotificationStore(now = Date.now()): ReadNotificationStore {
+  if (typeof window === 'undefined') return {};
+
+  try {
+    const raw = window.localStorage.getItem(NOTIFICATION_READ_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    const stored: ReadNotificationStore = Array.isArray(parsed)
+      ? Object.fromEntries(parsed.filter((id): id is string => typeof id === 'string').map((id) => [id, now]))
+      : parsed && typeof parsed === 'object' ? parsed as ReadNotificationStore : {};
+    const retained = Object.fromEntries(
+      Object.entries(stored).filter(([, readAt]) => typeof readAt === 'number' && now - readAt <= READ_NOTIFICATION_MAX_AGE_MS),
+    );
+    window.localStorage.setItem(NOTIFICATION_READ_STORAGE_KEY, JSON.stringify(retained));
+    return retained;
+  } catch {
+    return {};
+  }
+}
+
+export function readStoredNotificationIds(now = Date.now()): Set<string> {
+  return new Set(Object.keys(readStoredNotificationStore(now)));
+}
+
+function persistReadNotificationIds(ids: Set<string>, now = Date.now()) {
+  if (typeof window === 'undefined') return;
+  const value = readStoredNotificationStore(now);
+  ids.forEach((id) => {
+    if (!value[id]) value[id] = now;
+  });
+  window.localStorage.setItem(NOTIFICATION_READ_STORAGE_KEY, JSON.stringify(value));
+}
+
+/** Dashboard activity with local, browser-persisted read state. */
 export function useNotifications() {
+  const [readIds, setReadIds] = useState<Set<string>>(() => readStoredNotificationIds());
+  const query = useQuery({
+    queryKey: ['dashboard-activity'],
+    queryFn: () => get<Notification[]>('/dashboard/activity'),
+  });
+  const notifications = query.data ?? [];
+
+  const markAsRead = useCallback((id: string) => {
+    setReadIds((current) => {
+      if (current.has(id)) return current;
+      const next = new Set(current);
+      next.add(id);
+      persistReadNotificationIds(next);
+      return next;
+    });
+  }, []);
+
+  const markAllAsRead = useCallback(() => {
+    const ids = new Set(notifications.map((notification) => notification.id));
+    setReadIds((current) => {
+      const next = new Set([...current, ...ids]);
+      persistReadNotificationIds(next);
+      return next;
+    });
+  }, [notifications]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((notification) => !readIds.has(notification.id)).length,
+    [notifications, readIds],
+  );
+
+  return { ...query, notifications, readIds, unreadCount, markAsRead, markAllAsRead };
+}
+
+/** Existing socket toast notifications, kept separate from dashboard activity state. */
+export function useRealtimeNotifications() {
   const { accessToken, isAuthenticated } = useAuthStore();
   const { showToast } = useToast();
   const socketRef = useRef<Socket | null>(null);

--- a/frontend/src/providers/NotificationsInitializer.tsx
+++ b/frontend/src/providers/NotificationsInitializer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useNotifications } from '@/hooks/useNotifications';
+import { useRealtimeNotifications } from '@/hooks/useNotifications';
 
 export function NotificationsInitializer() {
-  useNotifications();
+  useRealtimeNotifications();
   return null;
 }


### PR DESCRIPTION
 This PR adds a dashboard notification center with localStorage-backed read/unread state.

  Users can open the notification center from the new bell icon in the dashboard header, view recent dashboard activity, see how many notifications are
  unread, mark individual notifications or all notifications as read, and navigate directly to the relevant dashboard context.

  ## What changed

  - Added a dashboard header notification bell with an unread-count badge.
  - Added NotificationCenter panel component with:
      - Recent activity notification list.
      - Read/unread visual state.
      - “Mark all read” action.
      - Empty state when no activity is available.
      - Outside-click and Escape-key dismissal.

  - Added activity-backed useNotifications hook:
      - Fetches dashboard activity from GET /dashboard/activity.
      - Derives unreadCount by comparing API notification IDs with locally persisted read IDs.
      - Exposes markAsRead and markAllAsRead.

  - Persisted read state in localStorage under hubassist:read-notification-ids.
      - Stores each read notification ID with a read timestamp.
      - Prunes entries older than 30 days to prevent unbounded storage growth.
      - Retains compatibility with an earlier array-style stored ID format.

  - Added click-to-navigate behavior:
      - Booking notifications navigate to /dashboard/bookings.
      - Attendance notifications navigate to /dashboard/attendance.
      - Membership and unmatched activity navigate to /profile.
      - API-supplied contextPath takes precedence when available.

  - Preserved existing websocket toast notifications by renaming the previous hook to useRealtimeNotifications.

  ## Tests

  Added coverage for:

  - Unread-count calculation when some notification IDs are already persisted as read.
  - Persisting a notification ID when it is marked as read.
  - Marking a notification read and navigating to its context page on click.
  - Dismissing the notification center with Escape or an outside click.

  ## Validation

  npm test -- --runInBand frontend/src/hooks/__tests__/useNotifications.test.tsx frontend/src/components/dashboard/__tests__/NotificationCenter.test.tsx
  npx tsc --noEmit

  Both checks pass.

closes #350 