### PR TITLE
feat(frontend): newsletter preference center with topic toggles and dirty-state tracking

### DIFF
--- a/frontend/__tests__/components/newsletter/NewsletterPreferences.test.tsx
+++ b/frontend/__tests__/components/newsletter/NewsletterPreferences.test.tsx
@@ -1,0 +1,248 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NewsletterPreferences } from "@/components/newsletter/NewsletterPreferences";
+import type { PreferenceFormData } from "@/components/newsletter/NewsletterPreferences";
+
+const defaultPreferences: PreferenceFormData = {
+  workspaceUpdates: true,
+  community: true,
+  promotions: true,
+  productUpdates: true,
+};
+
+const mockOnSave = jest.fn();
+const mockOnUnsubscribe = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOnSave.mockResolvedValue(undefined);
+  mockOnUnsubscribe.mockResolvedValue(undefined);
+});
+
+function renderComponent(overrides: Partial<React.ComponentProps<typeof NewsletterPreferences>> = {}) {
+  return render(
+    <NewsletterPreferences
+      initialPreferences={defaultPreferences}
+      onSave={mockOnSave}
+      onUnsubscribe={mockOnUnsubscribe}
+      {...overrides}
+    />
+  );
+}
+
+describe("NewsletterPreferences", () => {
+  describe("rendering", () => {
+    it("renders all four topic toggles", () => {
+      renderComponent();
+      expect(screen.getByLabelText(/workspace updates/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/community events/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/promotions & offers/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/product updates/i)).toBeInTheDocument();
+    });
+
+    it("renders privacy policy links for each topic", () => {
+      renderComponent();
+      const privacyLinks = screen.getAllByRole("link", { name: /privacy policy/i });
+      expect(privacyLinks).toHaveLength(4);
+      privacyLinks.forEach((link) => {
+        expect(link).toHaveAttribute("href", "/privacy-policy");
+      });
+    });
+
+    it("renders the save preferences button", () => {
+      renderComponent();
+      expect(screen.getByRole("button", { name: /save preferences/i })).toBeInTheDocument();
+    });
+
+    it("renders the unsubscribe link", () => {
+      renderComponent();
+      expect(screen.getByRole("button", { name: /unsubscribe from all emails/i })).toBeInTheDocument();
+    });
+
+    it("initialises checkboxes with given initialPreferences", () => {
+      renderComponent({
+        initialPreferences: {
+          workspaceUpdates: true,
+          community: false,
+          promotions: false,
+          productUpdates: true,
+        },
+      });
+
+      expect(screen.getByLabelText(/workspace updates/i)).toBeChecked();
+      expect(screen.getByLabelText(/community events/i)).not.toBeChecked();
+      expect(screen.getByLabelText(/promotions & offers/i)).not.toBeChecked();
+      expect(screen.getByLabelText(/product updates/i)).toBeChecked();
+    });
+
+    it("shows a loading spinner when isLoading is true", () => {
+      renderComponent({ isLoading: true });
+      expect(screen.getByText(/loading your preferences/i)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /save preferences/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("dirty state", () => {
+    it("does not show unsaved-changes indicator when form is pristine", () => {
+      renderComponent();
+      expect(screen.queryByText(/unsaved changes/i)).not.toBeInTheDocument();
+    });
+
+    it("shows unsaved-changes indicator after toggling a preference", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByLabelText(/community events/i));
+
+      expect(screen.getByText(/unsaved changes/i)).toBeInTheDocument();
+    });
+
+    it("hides unsaved-changes indicator after toggling back to original value", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      // Toggle off then back on — form should be clean again
+      await user.click(screen.getByLabelText(/community events/i));
+      expect(screen.getByText(/unsaved changes/i)).toBeInTheDocument();
+
+      await user.click(screen.getByLabelText(/community events/i));
+      expect(screen.queryByText(/unsaved changes/i)).not.toBeInTheDocument();
+    });
+
+    it("save button is disabled when form is pristine", () => {
+      renderComponent();
+      expect(screen.getByRole("button", { name: /save preferences/i })).toBeDisabled();
+    });
+
+    it("save button is enabled after a preference is toggled", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByLabelText(/community events/i));
+
+      expect(screen.getByRole("button", { name: /save preferences/i })).toBeEnabled();
+    });
+  });
+
+  describe("submitting with changes", () => {
+    it("calls onSave with only changed fields", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      // Toggle off community only
+      await user.click(screen.getByLabelText(/community events/i));
+      await user.click(screen.getByRole("button", { name: /save preferences/i }));
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledTimes(1);
+      });
+
+      // Only the changed field should be in the payload
+      const payload = mockOnSave.mock.calls[0][0];
+      expect(payload).toEqual({ community: false });
+      expect(payload).not.toHaveProperty("workspaceUpdates");
+      expect(payload).not.toHaveProperty("promotions");
+      expect(payload).not.toHaveProperty("productUpdates");
+    });
+
+    it("calls onSave with multiple changed fields when several are toggled", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByLabelText(/community events/i));
+      await user.click(screen.getByLabelText(/promotions & offers/i));
+      await user.click(screen.getByRole("button", { name: /save preferences/i }));
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledTimes(1);
+      });
+
+      const payload = mockOnSave.mock.calls[0][0];
+      expect(payload).toHaveProperty("community", false);
+      expect(payload).toHaveProperty("promotions", false);
+      expect(payload).not.toHaveProperty("workspaceUpdates");
+      expect(payload).not.toHaveProperty("productUpdates");
+    });
+
+    it("does not call onSave when no changes have been made", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      // Fire submit directly without toggling anything
+      // (button is disabled, so we can't click it, but let's verify via form submit)
+      const form = screen.getByRole("button", { name: /save preferences/i }).closest("form");
+      if (form) {
+        fireEvent.submit(form);
+      }
+
+      await waitFor(() => {
+        // onSave must NOT have been called because isDirty is false
+        expect(mockOnSave).not.toHaveBeenCalled();
+      });
+    });
+
+    it("shows success message after saving", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByLabelText(/community events/i));
+      await user.click(screen.getByRole("button", { name: /save preferences/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/preferences saved successfully/i)).toBeInTheDocument();
+      });
+    });
+
+    it("clears dirty state after a successful save", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByLabelText(/community events/i));
+      expect(screen.getByText(/unsaved changes/i)).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /save preferences/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText(/unsaved changes/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("submitting without changes (edge case via guard)", () => {
+    it("skips API call when the form is programmatically submitted with no dirty fields", async () => {
+      renderComponent();
+
+      const form = screen.getByRole("button", { name: /save preferences/i }).closest("form");
+      if (form) {
+        fireEvent.submit(form);
+      }
+
+      // Allow any async ticks to settle
+      await waitFor(() => {
+        expect(mockOnSave).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("calls onUnsubscribe when the unsubscribe button is clicked", async () => {
+      renderComponent();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole("button", { name: /unsubscribe from all emails/i }));
+
+      expect(mockOnUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables unsubscribe button while unsubscribing", () => {
+      renderComponent({ isUnsubscribing: true });
+      expect(screen.getByRole("button", { name: /unsubscribe from all emails/i })).toBeDisabled();
+    });
+
+    it("disables unsubscribe button while saving", () => {
+      renderComponent({ isSaving: true });
+      expect(screen.getByRole("button", { name: /unsubscribe from all emails/i })).toBeDisabled();
+    });
+  });
+});

--- a/frontend/__tests__/lib/react-query/useUpdateNewsletterPreferences.test.tsx
+++ b/frontend/__tests__/lib/react-query/useUpdateNewsletterPreferences.test.tsx
@@ -1,0 +1,219 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUpdateNewsletterPreferences } from "@/lib/react-query/hooks/newsletter/useUpdateNewsletterPreferences";
+import * as apiClient from "@/lib/apiClient";
+import React from "react";
+
+jest.mock("@/lib/apiClient");
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const createWrapper = (queryClient: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+describe("useUpdateNewsletterPreferences", () => {
+  let mockUpdateNewsletterPreferences: jest.Mock;
+  const token = "test-token-123";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateNewsletterPreferences = jest.fn();
+    (apiClient.api as any) = {
+      ...(apiClient.api as any),
+      updateNewsletterPreferences: mockUpdateNewsletterPreferences,
+    };
+  });
+
+  describe("successful update", () => {
+    it("calls api.updateNewsletterPreferences with correct token and data", async () => {
+      mockUpdateNewsletterPreferences.mockResolvedValueOnce({ message: "Updated" });
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      const preferences = { community: false, promotions: true };
+
+      await act(async () => {
+        result.current.mutate(preferences);
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockUpdateNewsletterPreferences).toHaveBeenCalledWith(token, preferences);
+      expect(mockUpdateNewsletterPreferences).toHaveBeenCalledTimes(1);
+    });
+
+    it("invalidates preferences query after successful update", async () => {
+      mockUpdateNewsletterPreferences.mockResolvedValueOnce({ message: "Updated" });
+
+      const queryClient = createTestQueryClient();
+      const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate({ promotions: false });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["newsletter", "preferences", token],
+      });
+    });
+
+    it("sets isSuccess to true on successful mutation", async () => {
+      mockUpdateNewsletterPreferences.mockResolvedValueOnce({ message: "Updated" });
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate({ productUpdates: false });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.isError).toBe(false);
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    it("sets isError to true when API call fails", async () => {
+      mockUpdateNewsletterPreferences.mockRejectedValueOnce(new Error("Server error"));
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate({ promotions: false });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+        expect(result.current.isSuccess).toBe(false);
+      });
+    });
+
+    it("does not invalidate queries when API call fails", async () => {
+      mockUpdateNewsletterPreferences.mockRejectedValueOnce(new Error("Network error"));
+
+      const queryClient = createTestQueryClient();
+      const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate({ community: false });
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(invalidateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mutation state", () => {
+    it("sets isPending to true while mutation is in progress", async () => {
+      let resolveUpdate!: (value: any) => void;
+      mockUpdateNewsletterPreferences.mockReturnValueOnce(
+        new Promise((resolve) => { resolveUpdate = resolve; })
+      );
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate({ promotions: false });
+      });
+
+      await waitFor(() => expect(result.current.isPending).toBe(true));
+
+      act(() => {
+        resolveUpdate({ message: "Updated" });
+      });
+
+      await waitFor(() => expect(result.current.isPending).toBe(false));
+    });
+
+    it("registers mutation under the correct mutation key", async () => {
+      mockUpdateNewsletterPreferences.mockReturnValueOnce(new Promise(() => {}));
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      act(() => {
+        result.current.mutate({ community: true });
+      });
+
+      const [mutation] = queryClient.getMutationCache().getAll();
+      expect(mutation?.options.mutationKey).toEqual(["newsletter", "preferences", "update", token]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles updating a single preference field", async () => {
+      mockUpdateNewsletterPreferences.mockResolvedValueOnce({ message: "Updated" });
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate({ workspaceUpdates: false });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockUpdateNewsletterPreferences).toHaveBeenCalledWith(token, {
+        workspaceUpdates: false,
+      });
+    });
+
+    it("handles updating multiple preference fields", async () => {
+      mockUpdateNewsletterPreferences.mockResolvedValueOnce({ message: "Updated" });
+
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(() => useUpdateNewsletterPreferences(token), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      const multiplePrefs = {
+        workspaceUpdates: false,
+        community: true,
+        promotions: false,
+      };
+
+      await act(async () => {
+        result.current.mutate(multiplePrefs);
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockUpdateNewsletterPreferences).toHaveBeenCalledWith(token, multiplePrefs);
+    });
+  });
+});

--- a/frontend/src/app/newsletter/preferences/layout.tsx
+++ b/frontend/src/app/newsletter/preferences/layout.tsx
@@ -1,0 +1,6 @@
+import { Suspense } from "react";
+import type { ReactNode } from "react";
+
+export default function NewsletterPreferencesLayout({ children }: { readonly children: ReactNode }) {
+  return <Suspense>{children}</Suspense>;
+}

--- a/frontend/src/app/newsletter/preferences/page.tsx
+++ b/frontend/src/app/newsletter/preferences/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { XCircle } from "lucide-react";
+import { NewsletterPreferences } from "@/components/newsletter/NewsletterPreferences";
+import {
+  useGetNewsletterPreferences,
+  useUpdateNewsletterPreferences,
+  useUnsubscribeNewsletter,
+} from "@/lib/react-query/hooks";
+import type { PreferenceFormData } from "@/components/newsletter/NewsletterPreferences";
+
+export default function NewsletterPreferencesPage() {
+  const token = useSearchParams().get("token");
+  const [isUnsubscribed, setIsUnsubscribed] = useState(false);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+  } = useGetNewsletterPreferences(token);
+
+  const updateMutation = useUpdateNewsletterPreferences(token ?? "");
+  const unsubscribeMutation = useUnsubscribeNewsletter(token ?? "");
+
+  // No token in URL
+  if (!token) {
+    return <InvalidTokenView reason="missing" />;
+  }
+
+  // Token validation error (404 = expired/invalid)
+  if (isError) {
+    const status = (error as { response?: { status?: number } })?.response?.status;
+    const reason = status === 404 ? "expired" : "invalid";
+    return <InvalidTokenView reason={reason} />;
+  }
+
+  // Unsubscribed confirmation screen
+  if (isUnsubscribed) {
+    return <UnsubscribedView />;
+  }
+
+  const initialPreferences = data
+    ? {
+        workspaceUpdates: data.preferences.workspaceUpdates ?? true,
+        community: data.preferences.community ?? true,
+        promotions: data.preferences.promotions ?? true,
+        productUpdates: data.preferences.productUpdates ?? true,
+      }
+    : undefined;
+
+  const handleSave = async (changedPrefs: Partial<PreferenceFormData>) => {
+    await updateMutation.mutateAsync(changedPrefs);
+  };
+
+  const handleUnsubscribe = async () => {
+    await unsubscribeMutation.mutateAsync();
+    setIsUnsubscribed(true);
+  };
+
+  return (
+    <NewsletterPreferences
+      initialPreferences={initialPreferences}
+      onSave={handleSave}
+      onUnsubscribe={handleUnsubscribe}
+      isLoading={isLoading}
+      isSaving={updateMutation.isPending}
+      isUnsubscribing={unsubscribeMutation.isPending}
+    />
+  );
+}
+
+// ─── Sub-views ──────────────────────────────────────────────────────────────
+
+interface InvalidTokenViewProps {
+  reason: "missing" | "expired" | "invalid";
+}
+
+function InvalidTokenView({ reason }: InvalidTokenViewProps) {
+  const messages: Record<InvalidTokenViewProps["reason"], { title: string; body: string }> = {
+    missing: {
+      title: "No preferences link provided",
+      body: "Please use the link sent to your email to manage your preferences.",
+    },
+    expired: {
+      title: "Link expired",
+      body: "This preferences link is no longer valid. Subscribe again to get a fresh link.",
+    },
+    invalid: {
+      title: "Invalid link",
+      body: "We couldn't recognize this link. Please use the most recent link from your email.",
+    },
+  };
+
+  const { title, body } = messages[reason];
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#C5BEB6] p-4">
+      <div className="w-full max-w-md rounded-2xl bg-[#F3EBE2] p-8 shadow-sm text-center">
+        <h1 className="mb-6 text-2xl font-semibold text-[#1A1A1A]">
+          HubAssist Newsletter
+        </h1>
+        <div className="flex flex-col items-center gap-4">
+          <XCircle className="h-10 w-10 text-[#D4916E]" />
+          <p className="text-base font-medium text-[#1A1A1A]">{title}</p>
+          <p className="text-sm text-[#6B6B6B]">{body}</p>
+          <Link
+            href="/"
+            className="mt-2 inline-block rounded-full bg-[#1A1A1A] px-6 py-2.5 text-sm font-medium text-[#F3EBE2] hover:bg-[#3D3D3D] transition-colors"
+          >
+            Re-subscribe
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UnsubscribedView() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#C5BEB6] p-4">
+      <div className="w-full max-w-md rounded-2xl bg-[#F3EBE2] p-8 shadow-sm text-center">
+        <h1 className="mb-6 text-2xl font-semibold text-[#1A1A1A]">
+          HubAssist Newsletter
+        </h1>
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-base font-medium text-[#1A1A1A]">
+            You have been unsubscribed
+          </p>
+          <p className="text-sm text-[#6B6B6B]">
+            You won&apos;t receive any further emails from us. You can always re-subscribe on our home page.
+          </p>
+          <Link
+            href="/"
+            className="mt-4 inline-block text-sm text-[#6B6B6B] underline hover:text-[#1A1A1A]"
+          >
+            Go to homepage
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/newsletter/NewsletterPreferences.tsx
+++ b/frontend/src/components/newsletter/NewsletterPreferences.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/Button";
+import { Loader2, AlertCircle, CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+export interface NewsletterTopic {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface PreferenceFormData {
+  workspaceUpdates: boolean;
+  community: boolean;
+  promotions: boolean;
+  productUpdates: boolean;
+}
+
+interface NewsletterPreferencesProps {
+  initialPreferences?: PreferenceFormData;
+  onSave: (data: Partial<PreferenceFormData>) => Promise<void>;
+  onUnsubscribe: () => Promise<void>;
+  isLoading?: boolean;
+  isSaving?: boolean;
+  isUnsubscribing?: boolean;
+}
+
+const topics: Array<NewsletterTopic & { key: keyof PreferenceFormData }> = [
+  {
+    id: "workspace-updates",
+    key: "workspaceUpdates",
+    label: "Workspace Updates",
+    description: "News about workspace availability, new spaces, and facility updates.",
+  },
+  {
+    id: "community",
+    key: "community",
+    label: "Community Events",
+    description: "Invitations to networking events, workshops, and community gatherings.",
+  },
+  {
+    id: "promotions",
+    key: "promotions",
+    label: "Promotions & Offers",
+    description: "Special discounts, seasonal offers, and exclusive deals.",
+  },
+  {
+    id: "product-updates",
+    key: "productUpdates",
+    label: "Product Updates",
+    description: "Platform improvements, new features, and service enhancements.",
+  },
+];
+
+export function NewsletterPreferences({
+  initialPreferences,
+  onSave,
+  onUnsubscribe,
+  isLoading = false,
+  isSaving = false,
+  isUnsubscribing = false,
+}: NewsletterPreferencesProps) {
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { isDirty, dirtyFields },
+  } = useForm<PreferenceFormData>({
+    defaultValues: initialPreferences || {
+      workspaceUpdates: true,
+      community: true,
+      promotions: true,
+      productUpdates: true,
+    },
+  });
+
+  // Reset form when initialPreferences change
+  useEffect(() => {
+    if (initialPreferences) {
+      reset(initialPreferences);
+    }
+  }, [initialPreferences, reset]);
+
+  // Clear success message after 3 seconds
+  useEffect(() => {
+    if (saveSuccess) {
+      const timer = setTimeout(() => setSaveSuccess(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [saveSuccess]);
+
+  const onSubmit = async (data: PreferenceFormData) => {
+    // Only send changed fields
+    const changedData: Partial<PreferenceFormData> = {};
+    Object.keys(dirtyFields).forEach((key) => {
+      changedData[key as keyof PreferenceFormData] = data[key as keyof PreferenceFormData];
+    });
+
+    if (Object.keys(changedData).length === 0) {
+      return; // No changes to save
+    }
+
+    await onSave(changedData);
+    reset(data); // Reset dirty state after successful save
+    setSaveSuccess(true);
+  };
+
+  const allValues = watch();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#C5BEB6] p-4">
+        <div className="w-full max-w-2xl rounded-2xl bg-[#F3EBE2] p-8 shadow-sm">
+          <div className="flex flex-col items-center gap-3 text-[#6B6B6B]">
+            <Loader2 className="h-8 w-8 animate-spin" />
+            <p className="text-sm">Loading your preferences…</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#C5BEB6] p-4">
+      <div className="w-full max-w-2xl rounded-2xl bg-[#F3EBE2] p-8 shadow-sm">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold text-[#1A1A1A]">Newsletter Preferences</h1>
+          <p className="mt-2 text-sm text-[#6B6B6B]">
+            Choose the topics you&apos;d like to receive updates about.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          {/* Topic Toggles */}
+          <div className="space-y-4">
+            {topics.map((topic) => (
+              <div
+                key={topic.id}
+                className={cn(
+                  "flex items-start gap-4 rounded-lg border p-4 transition-colors",
+                  allValues[topic.key]
+                    ? "border-[#1A1A1A] bg-white"
+                    : "border-[#D7CFC6] bg-[#EDE2D6]"
+                )}
+              >
+                <div className="flex items-start gap-3 flex-1">
+                  <input
+                    type="checkbox"
+                    id={topic.id}
+                    {...register(topic.key)}
+                    className="mt-1 h-5 w-5 rounded border-[#D7CFC6] text-[#1A1A1A] focus:ring-2 focus:ring-[#1A1A1A] focus:ring-offset-2"
+                  />
+                  <label htmlFor={topic.id} className="flex-1 cursor-pointer">
+                    <div className="font-medium text-[#1A1A1A]">{topic.label}</div>
+                    <div className="mt-1 text-sm text-[#6B6B6B]">{topic.description}</div>
+                    <a
+                      href="/privacy-policy"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-block text-xs text-[#6B6B6B] underline hover:text-[#1A1A1A]"
+                    >
+                      Privacy Policy
+                    </a>
+                  </label>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Unsaved Changes Indicator */}
+          {isDirty && (
+            <div className="flex items-center gap-2 rounded-lg bg-[#FFF8E1] px-4 py-3 text-sm text-[#1A1A1A]">
+              <AlertCircle className="h-4 w-4" />
+              <span>You have unsaved changes</span>
+            </div>
+          )}
+
+          {/* Success Message */}
+          {saveSuccess && (
+            <div className="flex items-center gap-2 rounded-lg bg-[#E8F5E9] px-4 py-3 text-sm text-[#1A1A1A]">
+              <CheckCircle2 className="h-4 w-4 text-[#A8C5A0]" />
+              <span>Preferences saved successfully</span>
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={!isDirty || isSaving}
+              loading={isSaving}
+              className="w-full sm:w-auto"
+            >
+              Save Preferences
+            </Button>
+
+            <button
+              type="button"
+              onClick={onUnsubscribe}
+              disabled={isUnsubscribing || isSaving}
+              className={cn(
+                "text-sm text-[#D4916E] underline hover:text-[#c07a58] disabled:opacity-50 disabled:pointer-events-none",
+                isUnsubscribing && "flex items-center gap-2"
+              )}
+            >
+              {isUnsubscribing && <Loader2 className="h-3 w-3 animate-spin" />}
+              Unsubscribe from all emails
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -226,4 +226,14 @@ export const api = {
 
   issueMembershipToken: (data: { userId: string; tier: number; expiryDate: string }) =>
     post<{ tokenId: string; message: string }>('/membership-tokens', data),
+
+  // Newsletter preferences (token-authenticated, no login required)
+  getNewsletterPreferences: (token: string) =>
+    get<import('@/types/newsletter').NewsletterPreferencesResponse>(`/newsletter/preferences/${token}`),
+
+  updateNewsletterPreferences: (token: string, preferences: Partial<import('@/types/newsletter').NewsletterPreferences>) =>
+    patch<{ message: string }>(`/newsletter/preferences/${token}`, preferences),
+
+  unsubscribeNewsletter: (token: string) =>
+    post<{ message: string }>(`/newsletter/unsubscribe/${token}`),
 };

--- a/frontend/src/lib/react-query/hooks/index.ts
+++ b/frontend/src/lib/react-query/hooks/index.ts
@@ -3,3 +3,6 @@ export { useRegisterUser } from "./auth/useRegisterUser";
 export { useForgotPassword } from "./auth/useForgotPassword";
 export { useConfirmBooking } from "./bookings/useConfirmBooking";
 export { useCancelBooking } from "./bookings/useCancelBooking";
+export { useGetNewsletterPreferences } from "./newsletter/useGetNewsletterPreferences";
+export { useUpdateNewsletterPreferences } from "./newsletter/useUpdateNewsletterPreferences";
+export { useUnsubscribeNewsletter } from "./newsletter/useUnsubscribeNewsletter";

--- a/frontend/src/lib/react-query/hooks/newsletter/useGetNewsletterPreferences.ts
+++ b/frontend/src/lib/react-query/hooks/newsletter/useGetNewsletterPreferences.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/apiClient";
+import type { NewsletterPreferencesResponse } from "@/types/newsletter";
+
+export function useGetNewsletterPreferences(token: string | null) {
+  return useQuery<NewsletterPreferencesResponse>({
+    queryKey: ["newsletter", "preferences", token],
+    queryFn: () => api.getNewsletterPreferences(token!),
+    enabled: !!token,
+    retry: false,
+  });
+}

--- a/frontend/src/lib/react-query/hooks/newsletter/useUnsubscribeNewsletter.ts
+++ b/frontend/src/lib/react-query/hooks/newsletter/useUnsubscribeNewsletter.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/apiClient";
+
+export function useUnsubscribeNewsletter(token: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["newsletter", "unsubscribe", token],
+    mutationFn: () => api.unsubscribeNewsletter(token),
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: ["newsletter", "preferences", token] });
+    },
+  });
+}

--- a/frontend/src/lib/react-query/hooks/newsletter/useUpdateNewsletterPreferences.ts
+++ b/frontend/src/lib/react-query/hooks/newsletter/useUpdateNewsletterPreferences.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/apiClient";
+import type { NewsletterPreferences } from "@/types/newsletter";
+
+export function useUpdateNewsletterPreferences(token: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["newsletter", "preferences", "update", token],
+    mutationFn: (preferences: Partial<NewsletterPreferences>) =>
+      api.updateNewsletterPreferences(token, preferences),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["newsletter", "preferences", token] });
+    },
+  });
+}

--- a/frontend/src/types/newsletter.ts
+++ b/frontend/src/types/newsletter.ts
@@ -1,0 +1,18 @@
+export interface NewsletterPreferences {
+  workspaceUpdates: boolean;
+  community: boolean;
+  promotions: boolean;
+  productUpdates: boolean;
+}
+
+export interface NewsletterSubscriber {
+  token: string;
+  email: string;
+  preferences: NewsletterPreferences;
+  subscribedAt: string;
+}
+
+export interface NewsletterPreferencesResponse {
+  preferences: NewsletterPreferences;
+  email: string;
+}


### PR DESCRIPTION
## Summary

Implements the Newsletter Preference Center as described in issue #357. Subscribers can visit `/newsletter/preferences?token=<token>` to manage their topic subscriptions without logging in — the URL token is the sole auth mechanism.

---

## What's Changed

### New Page — `/newsletter/preferences`
- Reads `?token=` from the URL and validates it against the API
- Distinct error states for **missing**, **expired** (404), and **invalid** tokens — each shows a clear message and a re-subscribe link
- Shows an **Unsubscribed** confirmation screen after opting out of all emails
- No login required; accessible to anyone with a valid token link

### New Component — `NewsletterPreferences.tsx`
Four topic toggles, each with a label, description, and Privacy Policy link:

| Topic key | Label |
|---|---|
| `workspaceUpdates` | Workspace Updates |
| `community` | Community Events |
| `promotions` | Promotions & Offers |
| `productUpdates` | Product Updates |

UX behaviour:
- **Unsaved Changes** badge appears as soon as any toggle differs from the saved state
- Badge disappears if the user toggles back to the original value (clean form)
- **Save Preferences** button is disabled while the form is clean or while saving
- On save: only the **changed fields** are sent in the PATCH request (dirty-field diffing via React Hook Form `dirtyFields`)
- Success message shown after a successful save; auto-dismissed after 3 s
- **Unsubscribe from all emails** link at the bottom calls the full unsubscribe endpoint

### API Client — `src/lib/apiClient.ts`
Three new methods added to the `api` object:
```ts
api.getNewsletterPreferences(token)           // GET   /newsletter/preferences/:token
api.updateNewsletterPreferences(token, prefs) // PATCH /newsletter/preferences/:token
api.unsubscribeNewsletter(token)              // POST  /newsletter/unsubscribe/:token
```

### React-Query Hooks
| Hook | Purpose |
|---|---|
| `useGetNewsletterPreferences(token)` | Fetch current preferences; disabled when token is null |
| `useUpdateNewsletterPreferences(token)` | PATCH changed fields; invalidates preferences query on success |
| `useUnsubscribeNewsletter(token)` | Unsubscribe-all; removes preferences cache on success |

### Types
`frontend/src/types/newsletter.ts` — `NewsletterPreferences`, `NewsletterPreferencesResponse`

---

## Tests

### Component tests — `NewsletterPreferences.test.tsx` (20 tests)
- Renders all four toggles with correct labels
- Renders a Privacy Policy link for each topic
- Initialises checkboxes from `initialPreferences` prop
- Shows loading spinner when `isLoading` is true
- **Dirty state:** badge appears on toggle; disappears when reverted
- **Save button:** disabled when clean, enabled after change
- **Submit:** sends only changed fields in payload
- **Submit with no changes:** does not call `onSave`
- Shows success message; clears dirty state after save
- Disables unsubscribe button while saving or unsubscribing

### Hook tests — `useUpdateNewsletterPreferences.test.tsx` (9 tests)
- Forwards correct token + data to the API
- Invalidates the preferences query on success
- Sets `isError` on failure; does **not** invalidate on failure
- Tracks `isPending` during in-flight request
- Registers under the correct mutation key
- Handles single and multiple changed fields

**All 151 tests pass. Production build succeeds with zero errors.**

---

## How to Test Manually

1. Start the backend and frontend (`npm run dev` from root).
2. Subscribe via the newsletter form on the landing page.
3. Click the confirmation link in the email (or grab a seed token from the DB).
4. Navigate to `http://localhost:3000/newsletter/preferences?token=<token>`.
5. Toggle any combination of topics → **Unsaved Changes** badge appears.
6. Toggle back → badge disappears (form is clean again).
7. Click **Save Preferences** → only changed topics are sent in the PATCH body.
8. Click **Unsubscribe from all emails** → confirmation screen is shown.
9. Visit the page with an invalid / expired token → appropriate error message shown with re-subscribe link.

---

Closes #357