### PR TITLE
feat(frontend): comprehensive WebAuthn error handling for BiometricLoginView

### DIFF
--- a/frontend/src/app/(auth)/login/LoginContent.tsx
+++ b/frontend/src/app/(auth)/login/LoginContent.tsx
@@ -22,35 +22,19 @@ function LoginContentInner() {
         <p className="mt-1 text-sm text-text-tertiary">Welcome back — enter your details below.</p>
       </div>
 
-      {showBiometric ? (
+      {showBiometric && (
         <>
-          <BiometricLoginView
-            onFallback={() => setShowBiometric(false)}
-          />
+          <BiometricLoginView onFallback={() => setShowBiometric(false)} />
 
           <div className="flex items-center gap-3">
             <hr className="flex-1 border-text/20" />
             <span className="text-xs text-text-tertiary">or</span>
             <hr className="flex-1 border-text/20" />
           </div>
-
-          <LoginForm />
-        </>
-      ) : (
-        <>
-          <LoginForm />
-
-          <div className="flex items-center gap-3">
-            <hr className="flex-1 border-text/20" />
-            <span className="text-xs text-text-tertiary">or</span>
-            <hr className="flex-1 border-text/20" />
-          </div>
-
-          <BiometricLoginView
-            onFallback={() => setShowBiometric(false)}
-          />
         </>
       )}
+
+      <LoginForm />
     </div>
   );
 }

--- a/frontend/src/components/auth/BiometricLoginView.tsx
+++ b/frontend/src/components/auth/BiometricLoginView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Fingerprint, AlertCircle } from "lucide-react";
 import { useAuthStore } from "@/lib/store/authStore";
 import apiClient from "@/lib/apiClient";
@@ -11,97 +11,140 @@ interface BiometricLoginViewProps {
   onFallback?: () => void;
 }
 
+const MAX_RETRIES = 3;
+
+/** Feature-detects a platform authenticator (Touch ID/Face ID/Windows Hello/etc). */
+export async function isBiometricSupported(): Promise<boolean> {
+  if (typeof window === "undefined" || window.PublicKeyCredential === undefined) {
+    return false;
+  }
+
+  try {
+    return await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Maps a WebAuthn failure to a user-friendly, actionable message.
+ * The raw DOMException.message is intentionally never surfaced to the user.
+ */
+function getBiometricErrorMessage(err: unknown): { message: string; isUnsupported: boolean } {
+  const name = typeof err === "object" && err !== null ? (err as { name?: string }).name : undefined;
+
+  switch (name) {
+    case "NotAllowedError":
+      return { message: "Authentication was cancelled. Please try again.", isUnsupported: false };
+    case "NotSupportedError":
+      return {
+        message: "Biometric authentication is not supported on this device or browser.",
+        isUnsupported: true,
+      };
+    case "InvalidStateError":
+      return {
+        message: "No biometric credential is set up for this account. Please use your password.",
+        isUnsupported: false,
+      };
+    case "SecurityError":
+      return {
+        message: "Biometric login requires a secure (HTTPS) connection.",
+        isUnsupported: false,
+      };
+    default:
+      break;
+  }
+
+  const responseMessage = (err as { response?: { data?: { message?: string } } } | undefined)?.response?.data
+    ?.message;
+
+  return {
+    message: responseMessage || "Biometric authentication failed. Please try again or use password login.",
+    isUnsupported: false,
+  };
+}
+
 export function BiometricLoginView({ onSuccess, onFallback }: BiometricLoginViewProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isSupported, setIsSupported] = useState(true);
+  const [isSupported, setIsSupported] = useState<boolean | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const [isDisabledForSession, setIsDisabledForSession] = useState(false);
   const login = useAuthStore((s) => s.login);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    isBiometricSupported().then((supported) => {
+      if (!isMounted) return;
+      setIsSupported(supported);
+      if (!supported) onFallback?.();
+    });
+
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleBiometricLogin = async () => {
     setIsLoading(true);
     setError(null);
 
     try {
-      // Check if WebAuthn is supported
-      if (!window.PublicKeyCredential) {
-        setIsSupported(false);
-        setError("Biometric authentication is not supported on this device or browser.");
-        return;
-      }
-
-      // Step 1: Get authentication options from server
       const { data: options } = await apiClient.post("/auth/biometric/login-options");
 
-      // Step 2: Use WebAuthn to authenticate
-      let credential;
-      try {
-        // Import dynamically to avoid SSR issues
-        const { startAuthentication } = await import('@simplewebauthn/browser');
-        credential = await startAuthentication(options);
-      } catch (authError: unknown) {
-        const e = authError as { name?: string };
-        if (e.name === "NotAllowedError") {
-          setError("Biometric authentication was cancelled or failed.");
-        } else if (e.name === "NotSupportedError") {
-          setError("Biometric authentication is not supported on this device.");
-          setIsSupported(false);
-        } else {
-          setError("Biometric authentication failed. Please try again.");
-        }
-        return;
-      }
+      // Import dynamically to avoid SSR issues
+      const { startAuthentication } = await import("@simplewebauthn/browser");
+      const credential = await startAuthentication(options);
 
-      // Step 3: Verify the authentication with the server
       const { data: authResult } = await apiClient.post("/auth/biometric/login-verify", {
         credential,
       });
 
-      // Step 4: Update auth state and redirect
       login({
         access_token: authResult.access_token,
         user: authResult.user,
       });
 
       onSuccess?.();
-      
-      // Redirect to dashboard
+
       if (typeof window !== "undefined") {
         window.location.href = "/dashboard";
       }
     } catch (err: unknown) {
-      console.error("Biometric login error:", err);
-      const e = err as { response?: { data?: { message?: string } } };
-      setError(
-        e.response?.data?.message || 
-        "Biometric authentication failed. Please try again or use password login."
-      );
+      const { message, isUnsupported } = getBiometricErrorMessage(err);
+      setError(message);
+
+      if (isUnsupported) {
+        // The platform genuinely doesn't support WebAuthn — hide entirely and let
+        // the parent fall back to password login.
+        setIsSupported(false);
+        onFallback?.();
+        return;
+      }
+
+      const nextRetryCount = retryCount + 1;
+      setRetryCount(nextRetryCount);
+      if (nextRetryCount >= MAX_RETRIES) {
+        setIsDisabledForSession(true);
+      }
     } finally {
       setIsLoading(false);
     }
   };
 
-  if (!isSupported) {
-    return (
-      <div className="space-y-4">
-        <div className="flex items-center gap-2 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-          <AlertCircle className="w-5 h-5 text-yellow-600" />
-          <p className="text-sm text-yellow-800">
-            Biometric authentication is not available on this device or browser.
-          </p>
-        </div>
-        {onFallback && (
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onFallback}
-            className="w-full"
-          >
-            Use password instead
-          </Button>
-        )}
-      </div>
-    );
+  // Still checking for platform authenticator support — render nothing to avoid a flash.
+  if (isSupported === null) {
+    return null;
   }
+
+  // Not supported — hide entirely and rely on the password login fallback rendered by the parent.
+  if (!isSupported) {
+    return null;
+  }
+
+  const attemptsRemaining = MAX_RETRIES - retryCount;
 
   return (
     <div className="space-y-4">
@@ -118,28 +161,43 @@ export function BiometricLoginView({ onSuccess, onFallback }: BiometricLoginView
       {error && (
         <div className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg">
           <AlertCircle className="w-4 h-4 text-red-600 flex-shrink-0" />
-          <p className="text-sm text-red-700">{error}</p>
+          <div>
+            <p className="text-sm text-red-700">{error}</p>
+            {!isDisabledForSession && retryCount > 0 && attemptsRemaining > 0 && (
+              <p className="text-xs text-red-600 mt-1">
+                {attemptsRemaining} attempt{attemptsRemaining === 1 ? "" : "s"} remaining before biometric login is
+                disabled for this session.
+              </p>
+            )}
+            {isDisabledForSession && (
+              <p className="text-xs text-red-600 mt-1">
+                Biometric login has been disabled for this session. Please use your password below.
+              </p>
+            )}
+          </div>
         </div>
       )}
 
-      <Button
-        type="button"
-        onClick={handleBiometricLogin}
-        disabled={isLoading}
-        className="w-full"
-      >
-        {isLoading ? (
-          <>
-            <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />
-            Authenticating...
-          </>
-        ) : (
-          <>
-            <Fingerprint className="w-4 h-4 mr-2" />
-            Sign in with Biometrics
-          </>
-        )}
-      </Button>
+      {!isDisabledForSession && (
+        <Button
+          type="button"
+          onClick={handleBiometricLogin}
+          disabled={isLoading}
+          className="w-full"
+        >
+          {isLoading ? (
+            <>
+              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />
+              Authenticating...
+            </>
+          ) : (
+            <>
+              <Fingerprint className="w-4 h-4 mr-2" />
+              Sign in with Biometrics
+            </>
+          )}
+        </Button>
+      )}
 
       {onFallback && (
         <Button

--- a/frontend/src/components/auth/__tests__/BiometricLoginView.test.tsx
+++ b/frontend/src/components/auth/__tests__/BiometricLoginView.test.tsx
@@ -1,0 +1,198 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { BiometricLoginView, isBiometricSupported } from "@/components/auth/BiometricLoginView";
+import apiClient from "@/lib/apiClient";
+import { startAuthentication } from "@simplewebauthn/browser";
+
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  default: { post: jest.fn() },
+}));
+
+jest.mock("@simplewebauthn/browser", () => ({
+  __esModule: true,
+  startAuthentication: jest.fn(),
+}));
+
+const mockLogin = jest.fn();
+jest.mock("@/lib/store/authStore", () => ({
+  useAuthStore: (selector: (state: { login: typeof mockLogin }) => unknown) =>
+    selector({ login: mockLogin }),
+}));
+
+const mockPost = apiClient.post as jest.Mock;
+const mockStartAuthentication = startAuthentication as jest.Mock;
+
+function setPlatformAuthenticatorAvailable(resolvedValue: boolean) {
+  Object.defineProperty(window, "PublicKeyCredential", {
+    configurable: true,
+    writable: true,
+    value: {
+      isUserVerifyingPlatformAuthenticatorAvailable: jest.fn().mockResolvedValue(resolvedValue),
+    } as unknown as typeof window.PublicKeyCredential,
+  });
+}
+
+function removePublicKeyCredentialSupport() {
+  Object.defineProperty(window, "PublicKeyCredential", {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  });
+}
+
+const originalError = console.error;
+beforeAll(() => {
+  // jsdom logs a "not implemented: navigation" error for the dashboard redirect; keep test output clean.
+  console.error = jest.fn();
+});
+afterAll(() => {
+  console.error = originalError;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPost.mockResolvedValue({ data: {} });
+});
+
+afterEach(() => {
+  removePublicKeyCredentialSupport();
+});
+
+describe("isBiometricSupported", () => {
+  it("returns false when PublicKeyCredential is unavailable", async () => {
+    removePublicKeyCredentialSupport();
+    await expect(isBiometricSupported()).resolves.toBe(false);
+  });
+
+  it("returns true when a platform authenticator is available", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    await expect(isBiometricSupported()).resolves.toBe(true);
+  });
+
+  it("returns false when the availability check throws", async () => {
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      writable: true,
+      value: {
+        isUserVerifyingPlatformAuthenticatorAvailable: jest.fn().mockRejectedValue(new Error("boom")),
+      } as unknown as typeof window.PublicKeyCredential,
+    });
+    await expect(isBiometricSupported()).resolves.toBe(false);
+  });
+});
+
+describe("BiometricLoginView", () => {
+  it("renders password login directly without the biometric option on unsupported browsers", async () => {
+    removePublicKeyCredentialSupport();
+    const onFallback = jest.fn();
+    render(<BiometricLoginView onFallback={onFallback} />);
+
+    await waitFor(() => expect(onFallback).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("button", { name: /sign in with biometrics/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the biometric button when a platform authenticator is available", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    render(<BiometricLoginView />);
+
+    expect(await screen.findByRole("button", { name: /sign in with biometrics/i })).toBeInTheDocument();
+  });
+
+  it("shows a cancelled message and increments the retry counter on NotAllowedError", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    mockStartAuthentication.mockRejectedValue(Object.assign(new Error("cancelled"), { name: "NotAllowedError" }));
+
+    render(<BiometricLoginView />);
+    fireEvent.click(await screen.findByRole("button", { name: /sign in with biometrics/i }));
+
+    expect(await screen.findByText("Authentication was cancelled. Please try again.")).toBeInTheDocument();
+    expect(screen.getByText(/2 attempts remaining/i)).toBeInTheDocument();
+  });
+
+  it("shows the HTTPS requirement message on SecurityError", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    mockStartAuthentication.mockRejectedValue(Object.assign(new Error("insecure"), { name: "SecurityError" }));
+
+    render(<BiometricLoginView />);
+    fireEvent.click(await screen.findByRole("button", { name: /sign in with biometrics/i }));
+
+    expect(await screen.findByText("Biometric login requires a secure (HTTPS) connection.")).toBeInTheDocument();
+  });
+
+  it("shows a re-enrollment message on InvalidStateError", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    mockStartAuthentication.mockRejectedValue(Object.assign(new Error("invalid state"), { name: "InvalidStateError" }));
+
+    render(<BiometricLoginView />);
+    fireEvent.click(await screen.findByRole("button", { name: /sign in with biometrics/i }));
+
+    expect(
+      await screen.findByText("No biometric credential is set up for this account. Please use your password."),
+    ).toBeInTheDocument();
+  });
+
+  it("never displays the raw DOMException message", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    mockStartAuthentication.mockRejectedValue(
+      Object.assign(new Error("raw-internal-webauthn-detail"), { name: "NotAllowedError" }),
+    );
+
+    render(<BiometricLoginView />);
+    fireEvent.click(await screen.findByRole("button", { name: /sign in with biometrics/i }));
+
+    await screen.findByText("Authentication was cancelled. Please try again.");
+    expect(screen.queryByText(/raw-internal-webauthn-detail/i)).not.toBeInTheDocument();
+  });
+
+  it("hides itself and falls back to password login on NotSupportedError", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    mockStartAuthentication.mockRejectedValue(
+      Object.assign(new Error("not supported"), { name: "NotSupportedError" }),
+    );
+    const onFallback = jest.fn();
+
+    render(<BiometricLoginView onFallback={onFallback} />);
+    fireEvent.click(await screen.findByRole("button", { name: /sign in with biometrics/i }));
+
+    await waitFor(() => expect(onFallback).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("button", { name: /sign in with biometrics/i })).not.toBeInTheDocument();
+  });
+
+  it("disables biometric login for the session after 3 failed attempts", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    mockStartAuthentication.mockRejectedValue(Object.assign(new Error("cancelled"), { name: "NotAllowedError" }));
+
+    render(<BiometricLoginView />);
+
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const button = await screen.findByRole("button", { name: /sign in with biometrics/i });
+      fireEvent.click(button);
+      await screen.findByText("Authentication was cancelled. Please try again.");
+    }
+
+    expect(
+      await screen.findByText("Biometric login has been disabled for this session. Please use your password below."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /sign in with biometrics/i })).not.toBeInTheDocument();
+  });
+
+  it("logs the user in and calls onSuccess when authentication succeeds", async () => {
+    setPlatformAuthenticatorAvailable(true);
+    mockStartAuthentication.mockResolvedValue({ id: "cred-id" });
+    mockPost.mockImplementation((url: string) => {
+      if (url === "/auth/biometric/login-options") return Promise.resolve({ data: { challenge: "abc" } });
+      if (url === "/auth/biometric/login-verify") {
+        return Promise.resolve({ data: { access_token: "token", user: { id: "1" } } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    const onSuccess = jest.fn();
+
+    render(<BiometricLoginView onSuccess={onSuccess} />);
+    fireEvent.click(await screen.findByRole("button", { name: /sign in with biometrics/i }));
+
+    await waitFor(() => expect(mockLogin).toHaveBeenCalledWith({ access_token: "token", user: { id: "1" } }));
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Closes #351.

`BiometricLoginView` only handled `NotAllowedError`/`NotSupportedError` with generic copy, never feature-detected before rendering, and had no retry limit — a user with a flaky sensor could hammer the WebAuthn prompt indefinitely.

## Changes

- Added `isBiometricSupported()`, which feature-detects a platform authenticator via `window.PublicKeyCredential !== undefined && PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()`. The component checks this on mount and renders nothing (hides gracefully) until support is confirmed.
- Mapped every relevant `DOMException.name` to a specific, actionable message — `NotAllowedError`, `NotSupportedError`, `InvalidStateError`, `SecurityError` — and a sensible default for anything else. The raw `DOMException.message` is never logged or shown.
- Added a 3-attempt retry counter: each failure (other than a hard unsupported-platform error) increments it and shows "N attempts remaining"; on the 3rd, biometric login is disabled for the rest of the session with an explanatory message, leaving password login as the way forward.
- A genuinely unsupported platform (`NotSupportedError`, or failing the initial feature check) hides the component entirely via `onFallback`, rather than showing its own "not supported" banner.
- Updated `LoginContent` so `LoginForm` (password login) always renders as the default, with `BiometricLoginView` and its "or" divider appearing only while biometric is supported/enabled — previously both were always rendered and merely reordered.

## Testing

- Added `frontend/src/components/auth/__tests__/BiometricLoginView.test.tsx`: unit tests for `isBiometricSupported()` (supported / unsupported / throws), each mapped error message (`NotAllowedError`, `SecurityError`, `InvalidStateError`), confirmation the raw exception message is never rendered, hiding on `NotSupportedError` with `onFallback` invoked, the 3-attempt session-disable flow, feature-detection gating the initial render, and the happy-path login/redirect.
- `npm run lint` — passes (only pre-existing, unrelated `<img>` warnings elsewhere).
- `npm run test:coverage` — all 18 suites / 134 tests pass.
- `npm run build` — production build and type-check succeed.