### PR TITLE
feat(frontend): add full keyboard navigation and Alt+N shortcuts to DashboardSidebar

### DIFF
--- a/frontend/__tests__/components/dashboard/DashboardSidebar.test.tsx
+++ b/frontend/__tests__/components/dashboard/DashboardSidebar.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for DashboardSidebar keyboard navigation and WCAG 2.1 AA compliance:
+ *   - aria-current="page" applied to the active route link only
+ *   - Tab order covers every nav link and the logout button
+ *   - Alt+N shortcuts navigate to the correct route
+ *   - Shortcuts are ignored while focus is inside an <input>
+ */
+
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
+
+// ─── Mock next/navigation ────────────────────────────────────────────────────
+const mockPush = jest.fn();
+let mockPathname = "/dashboard";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ─── Mock next/link ──────────────────────────────────────────────────────────
+// next/link renders an <a> in test; keep it simple to avoid RSC issues.
+jest.mock("next/link", () => {
+  const Link = ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  );
+  Link.displayName = "Link";
+  return Link;
+});
+
+// ─── Mock authStore ───────────────────────────────────────────────────────────
+jest.mock("@/lib/store/authStore", () => ({
+  useAuthStore: (selector: (s: { user: { firstname: string; role: string } | null; clear: () => void }) => unknown) =>
+    selector({
+      user: { firstname: "Alice", role: "admin" },
+      clear: jest.fn(),
+    }),
+}));
+
+// ─── Mock ThemeToggle ─────────────────────────────────────────────────────────
+jest.mock("@/components/ui/ThemeToggle", () => ({
+  ThemeToggle: () => <button aria-label="Toggle theme" />,
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderSidebar(pathname = "/dashboard") {
+  mockPathname = pathname;
+  mockPush.mockClear();
+  return render(<DashboardSidebar />);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("DashboardSidebar – aria-current", () => {
+  it('sets aria-current="page" on the active Dashboard link', () => {
+    renderSidebar("/dashboard");
+    const dashboardLink = screen.getByRole("link", { name: /dashboard/i });
+    expect(dashboardLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("does NOT set aria-current on inactive links", () => {
+    renderSidebar("/dashboard");
+    const inactiveLinks = screen
+      .getAllByRole("link")
+      .filter((el) => el.getAttribute("href") !== "/dashboard");
+
+    for (const link of inactiveLinks) {
+      expect(link).not.toHaveAttribute("aria-current");
+    }
+  });
+
+  it('sets aria-current="page" on /dashboard/bookings when that route is active', () => {
+    renderSidebar("/dashboard/bookings");
+    const bookingsLink = screen.getByRole("link", { name: /bookings/i });
+    expect(bookingsLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("moves aria-current when the pathname changes", () => {
+    const { rerender } = render(<DashboardSidebar />);
+
+    mockPathname = "/dashboard/workspaces";
+    rerender(<DashboardSidebar />);
+
+    const workspacesLink = screen.getByRole("link", { name: /workspaces/i });
+    expect(workspacesLink).toHaveAttribute("aria-current", "page");
+
+    const dashboardLink = screen.getByRole("link", { name: /^dashboard/i });
+    expect(dashboardLink).not.toHaveAttribute("aria-current");
+  });
+});
+
+describe("DashboardSidebar – Tab order (keyboard navigation)", () => {
+  it("all nav links are reachable via Tab (tabIndex=0)", async () => {
+    renderSidebar("/dashboard");
+    const user = userEvent.setup();
+
+    const navElement = screen.getByRole("navigation", { name: /sidebar navigation/i });
+    const links = within(navElement).getAllByRole("link");
+
+    // Every link must be focusable (tabIndex 0 or not set, both mean 0)
+    for (const link of links) {
+      const tabIndex = link.getAttribute("tabindex");
+      // tabIndex null (default) or "0" are both reachable
+      expect(tabIndex === null || tabIndex === "0").toBe(true);
+    }
+
+    // Navigate through all links via Tab from the first one
+    links[0].focus();
+    expect(links[0]).toHaveFocus();
+
+    for (let i = 1; i < links.length; i++) {
+      await user.tab();
+      expect(links[i]).toHaveFocus();
+    }
+  });
+
+  it("logout button is reachable via Tab after nav links", async () => {
+    renderSidebar("/dashboard");
+    const user = userEvent.setup();
+
+    const navElement = screen.getByRole("navigation", { name: /sidebar navigation/i });
+    const links = within(navElement).getAllByRole("link");
+
+    // Focus last nav link then tab to logout
+    links[links.length - 1].focus();
+    await user.tab();
+
+    const logoutBtn = screen.getByRole("button", { name: /log out/i });
+    expect(logoutBtn).toHaveFocus();
+  });
+});
+
+describe("DashboardSidebar – keyboard shortcuts (Alt+N)", () => {
+  it("Alt+3 navigates to /dashboard/bookings", async () => {
+    renderSidebar("/dashboard");
+    const user = userEvent.setup();
+
+    await user.keyboard("{Alt>}3{/Alt}");
+
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/bookings");
+  });
+
+  it("Alt+1 navigates to /dashboard", async () => {
+    renderSidebar("/dashboard/bookings");
+    const user = userEvent.setup();
+
+    await user.keyboard("{Alt>}1{/Alt}");
+
+    expect(mockPush).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("Alt+2 navigates to /dashboard/workspaces", async () => {
+    renderSidebar("/dashboard");
+    const user = userEvent.setup();
+
+    await user.keyboard("{Alt>}2{/Alt}");
+
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/workspaces");
+  });
+
+  it("shortcut is ignored while an input element has focus", async () => {
+    renderSidebar("/dashboard");
+    const user = userEvent.setup();
+
+    // Render an input and focus it
+    const { baseElement } = render(
+      <input data-testid="text-input" defaultValue="" />
+    );
+    const input = baseElement.querySelector("[data-testid='text-input']") as HTMLInputElement;
+    input.focus();
+
+    await user.keyboard("{Alt>}3{/Alt}");
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+describe("DashboardSidebar – ARIA landmarks", () => {
+  it("has an aside landmark with label 'Main navigation'", () => {
+    renderSidebar("/dashboard");
+    expect(
+      screen.getByRole("complementary", { name: /main navigation/i })
+    ).toBeInTheDocument();
+  });
+
+  it("nav inside aside is labelled 'Sidebar navigation'", () => {
+    renderSidebar("/dashboard");
+    expect(
+      screen.getByRole("navigation", { name: /sidebar navigation/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/DashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/DashboardSidebar.tsx
@@ -2,16 +2,28 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { useMemo } from "react";
 import { useAuthStore } from "@/lib/store/authStore";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import {
+  useKeyboardShortcuts,
+  formatShortcutLabel,
+  type KeyboardShortcut,
+} from "@/hooks/useKeyboardShortcuts";
 
 const NAV = [
-  { href: "/dashboard", label: "Dashboard", icon: "⊞" },
-  { href: "/dashboard/workspaces", label: "Workspaces", icon: "🏢" },
-  { href: "/dashboard/bookings", label: "Bookings", icon: "📅" },
-  { href: "/dashboard/attendance", label: "Attendance", icon: "🕐" },
-  { href: "/dashboard/profile", label: "Profile", icon: "👤" },
-  { href: "/dashboard/settings", label: "Settings", icon: "⚙️", adminOnly: true },
+  { href: "/dashboard", label: "Dashboard", icon: "⊞", shortcutKey: "1" },
+  { href: "/dashboard/workspaces", label: "Workspaces", icon: "🏢", shortcutKey: "2" },
+  { href: "/dashboard/bookings", label: "Bookings", icon: "📅", shortcutKey: "3" },
+  { href: "/dashboard/attendance", label: "Attendance", icon: "🕐", shortcutKey: "4" },
+  { href: "/dashboard/profile", label: "Profile", icon: "👤", shortcutKey: "5" },
+  {
+    href: "/dashboard/settings",
+    label: "Settings",
+    icon: "⚙️",
+    shortcutKey: "6",
+    adminOnly: true,
+  },
 ] as const;
 
 interface Props {
@@ -29,17 +41,48 @@ export function DashboardSidebar({ onClose }: Readonly<Props>) {
     router.push("/login");
   };
 
-  const links = NAV.filter((n) => !("adminOnly" in n && n.adminOnly && user?.role !== "admin"));
+  const links = NAV.filter(
+    (n) => !("adminOnly" in n && n.adminOnly && user?.role !== "admin")
+  );
+
+  // Build Alt+[1-N] shortcuts for each visible nav item
+  const shortcuts = useMemo<KeyboardShortcut[]>(
+    () =>
+      links.map((n) => ({
+        key: n.shortcutKey,
+        alt: true,
+        href: n.href,
+        label: `Alt+${n.shortcutKey}`,
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [links.map((l) => l.href).join(",")]
+  );
+
+  useKeyboardShortcuts(shortcuts);
 
   return (
-    <aside className="flex h-full w-64 flex-col bg-card border-r border-text/10">
-      {/* Logo */}
+    <aside
+      className="flex h-full w-64 flex-col bg-card border-r border-text/10"
+      aria-label="Main navigation"
+    >
+      {/* Logo / header */}
       <div className="flex items-center justify-between px-6 py-5 border-b border-text/10">
         <span className="text-lg font-semibold text-text">Hubassist</span>
         <div className="flex items-center gap-2">
           <ThemeToggle />
           {onClose && (
-            <button onClick={onClose} aria-label="Close menu" className="text-text-tertiary hover:text-text lg:hidden">
+            <button
+              onClick={onClose}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onClose();
+                }
+              }}
+              aria-label="Close menu"
+              tabIndex={0}
+              className="text-text-tertiary hover:text-text lg:hidden rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
               ✕
             </button>
           )}
@@ -47,40 +90,70 @@ export function DashboardSidebar({ onClose }: Readonly<Props>) {
       </div>
 
       {/* Nav */}
-      <nav className="flex-1 overflow-y-auto px-3 py-4 flex flex-col gap-1">
-        {links.map(({ href, label, icon }) => {
-          const active = pathname === href || (href !== "/dashboard" && pathname.startsWith(href));
+      <nav
+        className="flex-1 overflow-y-auto px-3 py-4 flex flex-col gap-1"
+        aria-label="Sidebar navigation"
+      >
+        {links.map(({ href, label, icon, shortcutKey }) => {
+          const active =
+            pathname === href ||
+            (href !== "/dashboard" && pathname.startsWith(href));
+          const shortcutLabel = formatShortcutLabel({ key: shortcutKey, alt: true });
+
           return (
             <Link
               key={href}
               href={href}
               onClick={onClose}
-              className={`flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${
+              tabIndex={0}
+              aria-current={active ? "page" : undefined}
+              aria-label={`${label} (${shortcutLabel})`}
+              title={`${label} — ${shortcutLabel}`}
+              className={[
+                "flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current",
                 active
                   ? "bg-text text-canvas"
-                  : "text-text-secondary hover:bg-text/5"
-              }`}
+                  : "text-text-secondary hover:bg-text/5",
+              ].join(" ")}
             >
-              <span className="text-base leading-none">{icon}</span>
-              {label}
+              <span className="text-base leading-none" aria-hidden="true">
+                {icon}
+              </span>
+              <span className="flex-1">{label}</span>
+              {/* Keyboard shortcut hint — visible on hover via opacity */}
+              <span
+                className="ml-auto text-[10px] opacity-0 group-hover:opacity-60 focus-within:opacity-60 tabular-nums"
+                aria-hidden="true"
+              >
+                {shortcutLabel}
+              </span>
             </Link>
           );
         })}
       </nav>
 
-      {/* User + Logout */}
+      {/* User info + logout */}
       <div className="border-t border-text/10 px-4 py-4 flex items-center gap-3">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-sage text-sm font-semibold text-text">
+        <div
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-sage text-sm font-semibold text-text"
+          aria-hidden="true"
+        >
           {user?.firstname?.[0]?.toUpperCase() ?? "?"}
         </div>
         <div className="flex-1 min-w-0">
-          <p className="truncate text-sm font-medium text-text">{user?.firstname ?? "User"}</p>
-          <p className="truncate text-xs capitalize text-text-tertiary">{user?.role ?? "member"}</p>
+          <p className="truncate text-sm font-medium text-text">
+            {user?.firstname ?? "User"}
+          </p>
+          <p className="truncate text-xs capitalize text-text-tertiary">
+            {user?.role ?? "member"}
+          </p>
         </div>
         <button
           onClick={handleLogout}
           aria-label="Log out"
-          className="shrink-0 rounded-lg p-1.5 text-text-tertiary hover:bg-text/5 hover:text-text transition-colors"
+          tabIndex={0}
+          className="shrink-0 rounded-lg p-1.5 text-text-tertiary hover:bg-text/5 hover:text-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current"
         >
           ↩
         </button>

--- a/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for useKeyboardShortcuts hook:
+ *   - Registers keydown listener on mount
+ *   - Calls router.push for href shortcuts
+ *   - Calls onTrigger callback shortcuts
+ *   - Ignores shortcuts while focus is in an input / textarea / select
+ *   - Ignores shortcuts for non-matching keys
+ *   - formatShortcutLabel builds readable labels
+ */
+
+import { renderHook } from "@testing-library/react";
+import { fireEvent } from "@testing-library/dom";
+import {
+  useKeyboardShortcuts,
+  formatShortcutLabel,
+  type KeyboardShortcut,
+} from "@/hooks/useKeyboardShortcuts";
+
+// ─── Mock next/navigation ─────────────────────────────────────────────────────
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fireKey(
+  key: string,
+  modifiers: { altKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean } = {},
+  target: EventTarget = document
+) {
+  fireEvent.keyDown(target, { key, ...modifiers });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useKeyboardShortcuts", () => {
+  beforeEach(() => mockPush.mockClear());
+
+  it("calls router.push with the matching href on Alt+1", () => {
+    const shortcuts: KeyboardShortcut[] = [
+      { key: "1", alt: true, href: "/dashboard" },
+    ];
+    renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    fireKey("1", { altKey: true });
+
+    expect(mockPush).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("calls the onTrigger callback when provided", () => {
+    const onTrigger = jest.fn();
+    const shortcuts: KeyboardShortcut[] = [
+      { key: "Escape", onTrigger },
+    ];
+    renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    fireKey("Escape");
+
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call router.push when no shortcut matches", () => {
+    const shortcuts: KeyboardShortcut[] = [
+      { key: "1", alt: true, href: "/dashboard" },
+    ];
+    renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    // Wrong modifier
+    fireKey("1", { ctrlKey: true });
+    // Wrong key
+    fireKey("9", { altKey: true });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("ignores shortcuts when focus is inside an <input>", () => {
+    const shortcuts: KeyboardShortcut[] = [
+      { key: "1", alt: true, href: "/dashboard" },
+    ];
+    renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    fireKey("1", { altKey: true }, input);
+
+    document.body.removeChild(input);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("ignores shortcuts when focus is inside a <textarea>", () => {
+    const shortcuts: KeyboardShortcut[] = [
+      { key: "1", alt: true, href: "/dashboard" },
+    ];
+    renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+
+    fireKey("1", { altKey: true }, textarea);
+
+    document.body.removeChild(textarea);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("ignores shortcuts when focus is inside a <select>", () => {
+    const shortcuts: KeyboardShortcut[] = [
+      { key: "1", alt: true, href: "/dashboard" },
+    ];
+    renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    const select = document.createElement("select");
+    document.body.appendChild(select);
+
+    fireKey("1", { altKey: true }, select);
+
+    document.body.removeChild(select);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("removes the event listener on unmount", () => {
+    const shortcuts: KeyboardShortcut[] = [
+      { key: "1", alt: true, href: "/dashboard" },
+    ];
+    const { unmount } = renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    unmount();
+    fireKey("1", { altKey: true });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("only triggers the first matching shortcut in the list", () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const shortcuts: KeyboardShortcut[] = [
+      { key: "x", onTrigger: first },
+      { key: "x", onTrigger: second },
+    ];
+    renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    fireKey("x");
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatShortcutLabel", () => {
+  it("builds Alt+1 label", () => {
+    expect(formatShortcutLabel({ key: "1", alt: true })).toBe("Alt+1");
+  });
+
+  it("builds Ctrl+Shift+S label", () => {
+    expect(
+      formatShortcutLabel({ key: "s", ctrl: true, shift: true })
+    ).toBe("Ctrl+Shift+S");
+  });
+
+  it("builds a plain key label with no modifiers", () => {
+    expect(formatShortcutLabel({ key: "Escape" })).toBe("ESCAPE");
+  });
+});

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export interface KeyboardShortcut {
+  /** The key to match (e.g. "1", "2", "ArrowUp") */
+  key: string;
+  /** Require Alt modifier key */
+  alt?: boolean;
+  /** Require Ctrl modifier key */
+  ctrl?: boolean;
+  /** Require Shift modifier key */
+  shift?: boolean;
+  /** Navigation href – if provided, calls router.push on match */
+  href?: string;
+  /** Custom callback – called instead of (or in addition to) href navigation */
+  onTrigger?: () => void;
+  /** Human-readable label for the shortcut (e.g. "Alt+1") */
+  label?: string;
+}
+
+/**
+ * Registers a list of keyboard shortcuts on the document.
+ *
+ * All shortcuts are removed when the component that called this hook unmounts,
+ * so there is no risk of stale handlers accumulating.
+ *
+ * Design notes
+ * ─────────────
+ * • Alt+[1-9] shortcuts are used because they do not conflict with common
+ *   browser defaults (Ctrl+T, Ctrl+W, F5, etc.) on Windows, macOS, or Linux.
+ * • The handler uses `event.preventDefault()` only when a shortcut matches,
+ *   so unmatched key combinations pass through untouched.
+ * • Input / textarea / contentEditable elements are excluded to avoid
+ *   hijacking text entry.
+ */
+export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]): void {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      // Skip when the user is typing in an input-like element
+      const target = event.target as HTMLElement;
+      const tag = target.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      for (const shortcut of shortcuts) {
+        const altMatch = shortcut.alt ? event.altKey : !event.altKey;
+        const ctrlMatch = shortcut.ctrl ? event.ctrlKey : !event.ctrlKey;
+        const shiftMatch = shortcut.shift ? event.shiftKey : !event.shiftKey;
+        const keyMatch = event.key === shortcut.key;
+
+        if (keyMatch && altMatch && ctrlMatch && shiftMatch) {
+          event.preventDefault();
+
+          if (shortcut.onTrigger) {
+            shortcut.onTrigger();
+          }
+
+          if (shortcut.href) {
+            router.push(shortcut.href);
+          }
+
+          // Stop checking further shortcuts once one matched
+          break;
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => {
+      document.removeEventListener("keydown", handler);
+    };
+  }, [shortcuts, router]);
+}
+
+/**
+ * Builds the human-readable label for a shortcut (e.g. "Alt+1").
+ * Exported so components can render it in tooltips.
+ */
+export function formatShortcutLabel(shortcut: KeyboardShortcut): string {
+  const parts: string[] = [];
+  if (shortcut.ctrl) parts.push("Ctrl");
+  if (shortcut.alt) parts.push("Alt");
+  if (shortcut.shift) parts.push("Shift");
+  parts.push(shortcut.key.toUpperCase());
+  return parts.join("+");
+}


### PR DESCRIPTION
closes #349 
## Summary

Implements full keyboard navigation for `DashboardSidebar.tsx`, satisfying WCAG 2.1 AA keyboard guidelines.

## Changes

### New: `useKeyboardShortcuts` hook (`frontend/src/hooks/useKeyboardShortcuts.ts`)
- Registers `Alt+[1-N]` shortcuts on `document` for top-level nav items
- Skips triggering inside `<input>`, `<textarea>`, `<select>`, or `contentEditable` elements to avoid text-entry conflicts
- Cleans up the `keydown` listener on unmount — no stale handlers
- Exports `formatShortcutLabel` helper for tooltip display (e.g. `"Alt+1"`)

### Updated: `DashboardSidebar.tsx`
- `tabIndex={0}` on all interactive elements (nav links, close button, logout button)
- `aria-current="page"` dynamically set on the active route link via `usePathname()`
- `aria-label` on `<aside>` (`"Main navigation"`) and `<nav>` (`"Sidebar navigation"`)
- Each link carries `aria-label` including the shortcut hint (e.g. `"Dashboard (Alt+1)"`) and a `title` tooltip
- `focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2` focus rings on all interactive elements — not removed via CSS
- `useKeyboardShortcuts` called with `Alt+[1-6]` mapped to nav hrefs

## Tests

23 new tests across 2 new test files (all 145 tests in the full suite pass):

| File | Coverage |
|---|---|
| `__tests__/components/dashboard/DashboardSidebar.test.tsx` | `aria-current` set/unset on route change; Tab order through all nav links; logout button reachable via Tab; `Alt+1/2/3` navigation; shortcut ignored in `<input>`; `<aside>` and `<nav>` ARIA landmarks |
| `src/hooks/__tests__/useKeyboardShortcuts.test.ts` | `router.push` called on match; `onTrigger` callback; no match on wrong modifier/key; ignored in `<input>`, `<textarea>`, `<select>`; listener removed on unmount; first-match-only; `formatShortcutLabel` |

## Keyboard shortcuts

| Shortcut | Route |
|---|---|
| Alt+1 | /dashboard |
| Alt+2 | /dashboard/workspaces |
| Alt+3 | /dashboard/bookings |
| Alt+4 | /dashboard/attendance |
| Alt+5 | /dashboard/profile |
| Alt+6 | /dashboard/settings (admin only) |