### PR TITLE
feat(frontend): workspace live search with debounced input and highlighted results

### DIFF
--- a/frontend/__tests__/components/workspaces/HighlightText.test.tsx
+++ b/frontend/__tests__/components/workspaces/HighlightText.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { HighlightText } from "@/components/workspaces/HighlightText";
+
+describe("HighlightText", () => {
+  it("renders the full text as-is when query is empty", () => {
+    render(<HighlightText text="Open Office Space" query="" />);
+    expect(screen.getByText("Open Office Space")).toBeInTheDocument();
+    expect(document.querySelector("mark")).toBeNull();
+  });
+
+  it("renders the full text as-is when query is a single character", () => {
+    render(<HighlightText text="Open Office Space" query="O" />);
+    // No <mark> should appear — single char below 2-char minimum
+    expect(document.querySelector("mark")).toBeNull();
+  });
+
+  it("wraps matched substring in a <mark> element", () => {
+    const { container } = render(<HighlightText text="Open Office Space" query="Office" />);
+    const mark = container.querySelector("mark");
+    expect(mark).not.toBeNull();
+    expect(mark?.textContent).toBe("Office");
+  });
+
+  it("is case-insensitive when matching", () => {
+    const { container } = render(<HighlightText text="Open Office Space" query="office" />);
+    const mark = container.querySelector("mark");
+    expect(mark).not.toBeNull();
+    expect(mark?.textContent).toBe("Office");
+  });
+
+  it("highlights multiple occurrences", () => {
+    const { container } = render(
+      <HighlightText text="desk next to a bigger desk" query="desk" />
+    );
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(2);
+    marks.forEach((m) => expect(m.textContent).toBe("desk"));
+  });
+
+  it("preserves non-matching portions of the text outside <mark>", () => {
+    const { container } = render(
+      <HighlightText text="Conference Room A" query="Room" />
+    );
+    // Total text content should remain the same
+    expect(container.textContent).toBe("Conference Room A");
+    expect(container.querySelector("mark")?.textContent).toBe("Room");
+  });
+
+  it("does not highlight when query is not found in text", () => {
+    render(<HighlightText text="Meeting Room" query="xyz" />);
+    expect(document.querySelector("mark")).toBeNull();
+    expect(screen.getByText("Meeting Room")).toBeInTheDocument();
+  });
+
+  it("applies the default mark class", () => {
+    const { container } = render(<HighlightText text="Private Office" query="Office" />);
+    const mark = container.querySelector("mark");
+    expect(mark?.className).toMatch(/bg-yellow-200/);
+  });
+
+  it("applies a custom markClassName when provided", () => {
+    const { container } = render(
+      <HighlightText text="Private Office" query="Office" markClassName="custom-highlight" />
+    );
+    const mark = container.querySelector("mark");
+    expect(mark?.className).toBe("custom-highlight");
+  });
+
+  it("applies className to the wrapping <span>", () => {
+    const { container } = render(
+      <HighlightText text="Hot Desk" query="Desk" className="wrapper-class" />
+    );
+    const span = container.querySelector("span");
+    expect(span?.className).toBe("wrapper-class");
+  });
+
+  it("renders the full text with no marks when query is whitespace only", () => {
+    render(<HighlightText text="Conference Room" query="   " />);
+    expect(document.querySelector("mark")).toBeNull();
+  });
+
+  it("handles special regex characters in the query safely", () => {
+    const { container } = render(
+      <HighlightText text="Office (A)" query="(" />
+    );
+    // Single char — no highlight expected
+    expect(document.querySelector("mark")).toBeNull();
+
+    // Two-char query that includes a special regex character
+    const { container: c2 } = render(
+      <HighlightText text="Office (A)" query="(A" />
+    );
+    const mark = c2.querySelector("mark");
+    expect(mark).not.toBeNull();
+    expect(mark?.textContent).toBe("(A");
+  });
+});

--- a/frontend/__tests__/lib/react-query/useWorkspaces.test.tsx
+++ b/frontend/__tests__/lib/react-query/useWorkspaces.test.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useWorkspaces } from "@/lib/react-query/hooks/workspaces/useWorkspaces";
+import * as apiClient from "@/lib/apiClient";
+import { createWrapper } from "./test-utils";
+import type { Workspace } from "@/types/workspace";
+
+jest.mock("@/lib/apiClient");
+
+const makeWorkspace = (overrides?: Partial<Workspace>): Workspace => ({
+  id: "ws-1",
+  name: "Open Desk",
+  type: "desk",
+  capacity: 1,
+  pricePerHour: 10,
+  availability: true,
+  description: "A comfortable open desk",
+  amenities: [],
+  images: [],
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+  ...overrides,
+});
+
+describe("useWorkspaces", () => {
+  let mockGetWorkspaces: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetWorkspaces = jest.fn();
+    (apiClient.api as any) = {
+      ...(apiClient.api as any),
+      getWorkspaces: mockGetWorkspaces,
+    };
+  });
+
+  it("calls getWorkspaces with no params when no options are provided", async () => {
+    mockGetWorkspaces.mockResolvedValueOnce({ workspaces: [makeWorkspace()] });
+
+    const { result } = renderHook(() => useWorkspaces(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetWorkspaces).toHaveBeenCalledWith({});
+  });
+
+  it("does not include search in params when query is a single character", async () => {
+    mockGetWorkspaces.mockResolvedValueOnce({ workspaces: [] });
+
+    const { result } = renderHook(() => useWorkspaces({ search: "a" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // search="a" — below 2-char minimum — should not appear in params
+    expect(mockGetWorkspaces).toHaveBeenCalledWith({});
+  });
+
+  it("does not include search in params when query is empty", async () => {
+    mockGetWorkspaces.mockResolvedValueOnce({ workspaces: [] });
+
+    const { result } = renderHook(() => useWorkspaces({ search: "" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetWorkspaces).toHaveBeenCalledWith({});
+  });
+
+  it("includes search in params when query is 2 or more characters", async () => {
+    mockGetWorkspaces.mockResolvedValueOnce({ workspaces: [makeWorkspace()] });
+
+    const { result } = renderHook(() => useWorkspaces({ search: "de" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetWorkspaces).toHaveBeenCalledWith({ search: "de" });
+  });
+
+  it("trims the search string before passing it to the API", async () => {
+    mockGetWorkspaces.mockResolvedValueOnce({ workspaces: [] });
+
+    const { result } = renderHook(() => useWorkspaces({ search: "  desk  " }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetWorkspaces).toHaveBeenCalledWith({ search: "desk" });
+  });
+
+  it("includes filter params alongside search", async () => {
+    mockGetWorkspaces.mockResolvedValueOnce({ workspaces: [] });
+
+    const { result } = renderHook(
+      () => useWorkspaces({ search: "office", type: "office", availability: true }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetWorkspaces).toHaveBeenCalledWith({
+      search: "office",
+      type: "office",
+      availability: true,
+    });
+  });
+
+  it("uses different query keys for different search terms (cache isolation)", () => {
+    // We verify this behaviorally: the two hooks fetch independently with
+    // different params, meaning React Query treats them as separate cache entries.
+    mockGetWorkspaces
+      .mockResolvedValueOnce({ workspaces: [makeWorkspace({ id: "ws-desk", name: "Desk" })] })
+      .mockResolvedValueOnce({ workspaces: [makeWorkspace({ id: "ws-office", name: "Office" })] });
+
+    const wrapperInstance = createWrapper();
+    const { result: r1 } = renderHook(() => useWorkspaces({ search: "desk" }), {
+      wrapper: wrapperInstance,
+    });
+    const { result: r2 } = renderHook(() => useWorkspaces({ search: "office" }), {
+      wrapper: wrapperInstance,
+    });
+
+    // Both hooks were rendered — each will call the API independently
+    expect(mockGetWorkspaces).toHaveBeenCalledWith({ search: "desk" });
+    expect(mockGetWorkspaces).toHaveBeenCalledWith({ search: "office" });
+    expect(mockGetWorkspaces).toHaveBeenCalledTimes(2);
+
+    // Suppress unused variable warnings — results exist, hooks rendered
+    void r1;
+    void r2;
+  });
+
+  it("returns workspace data correctly when query succeeds", async () => {
+    const workspaces = [makeWorkspace({ id: "ws-1", name: "Cozy Office" })];
+    mockGetWorkspaces.mockResolvedValueOnce({ workspaces });
+
+    const { result } = renderHook(() => useWorkspaces({ search: "cozy" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.workspaces).toEqual(workspaces);
+  });
+
+  it("exposes isError when the API call fails", async () => {
+    mockGetWorkspaces.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useWorkspaces({ search: "fail" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/frontend/src/app/workspaces/page.tsx
+++ b/frontend/src/app/workspaces/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { Suspense } from "react";
-import { useQuery } from "@tanstack/react-query";
-import type { Workspace, WorkspaceFilters, WorkspaceType } from "@/types/workspace";
-import { api } from "@/lib/apiClient";
+import type { WorkspaceFilters, WorkspaceType } from "@/types/workspace";
 import { Button } from "@/components/ui/Button";
 import { WorkspaceFiltersComponent } from "@/components/workspaces/WorkspaceFilters";
+import { HighlightText } from "@/components/workspaces/HighlightText";
 import { useFiltersWithUrl, type FilterSchema } from "@/hooks/useFiltersWithUrl";
-import { booleanCodec, enumCodec, numberCodec } from "@/lib/filters/codecs";
+import { useDebounce } from "@/hooks/useDebounce";
+import { useWorkspaces } from "@/lib/react-query/hooks/workspaces/useWorkspaces";
+import { booleanCodec, enumCodec, numberCodec, stringCodec } from "@/lib/filters/codecs";
 
 const WORKSPACE_TYPES: WorkspaceType[] = ["office", "meeting-room", "desk", "conference-room"];
 
@@ -18,88 +19,77 @@ const WORKSPACE_FILTERS_SCHEMA: FilterSchema<WorkspaceFilters> = {
   availability: booleanCodec(),
   minPrice: numberCodec(),
   maxPrice: numberCodec(),
+  search: stringCodec(),
 };
 
-interface WorkspacesResponse {
-  workspaces: Workspace[];
+function getTypeBadgeColor(type: WorkspaceType) {
+  switch (type) {
+    case "office":
+      return "bg-blue-100 text-blue-800";
+    case "meeting-room":
+      return "bg-green-100 text-green-800";
+    case "desk":
+      return "bg-yellow-100 text-yellow-800";
+    case "conference-room":
+      return "bg-purple-100 text-purple-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
 }
 
-function WorkspaceCard({ workspace }: { workspace: Workspace }) {
-  const getTypeBadgeColor = (type: WorkspaceType) => {
-    switch (type) {
-      case "office":
-        return "bg-blue-100 text-blue-800";
-      case "meeting-room":
-        return "bg-green-100 text-green-800";
-      case "desk":
-        return "bg-yellow-100 text-yellow-800";
-      case "conference-room":
-        return "bg-purple-100 text-purple-800";
-      default:
-        return "bg-gray-100 text-gray-800";
-    }
-  };
-
+function WorkspaceSkeleton() {
   return (
-    <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow">
-      <div className="h-48 bg-gray-200 flex items-center justify-center">
-        {workspace.images?.[0] ? (
-          <img
-            src={workspace.images[0]}
-            alt={workspace.name}
-            className="w-full h-full object-cover"
-          />
-        ) : (
-          <div className="text-gray-500">No Image</div>
-        )}
+    <div className="max-w-7xl mx-auto p-6">
+      <div className="mb-8">
+        <div className="h-8 bg-gray-200 rounded w-1/4 mb-2 animate-pulse" />
+        <div className="h-4 bg-gray-200 rounded w-1/3 animate-pulse" />
       </div>
-      <div className="p-4">
-        <div className="flex items-center justify-between mb-2">
-          <h3 className="text-lg font-semibold">{workspace.name}</h3>
-          <span className={`px-2 py-1 rounded-full text-xs font-medium ${getTypeBadgeColor(workspace.type)}`}>
-            {workspace.type.replace("-", " ")}
-          </span>
-        </div>
-        <p className="text-gray-600 text-sm mb-2">
-          Capacity: {workspace.capacity} • ${workspace.pricePerHour}/hour
-        </p>
-        <p className="text-gray-600 text-sm mb-4">
-          {workspace.availability ? (
-            <span className="text-green-600">Available</span>
-          ) : (
-            <span className="text-red-600">Unavailable</span>
-          )}
-        </p>
-        <Button className="w-full" disabled={!workspace.availability}>
-          {workspace.availability ? "Book Now" : "Unavailable"}
-        </Button>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className="bg-white rounded-lg shadow-md h-80 animate-pulse" />
+        ))}
       </div>
     </div>
   );
 }
 
 function WorkspacesContent() {
+  // URL-synced filters (includes search for shareability)
   const [filters, setFilters] = useFiltersWithUrl(DEFAULT_WORKSPACE_FILTERS, WORKSPACE_FILTERS_SCHEMA);
 
-  const { data, isLoading, isError } = useQuery<WorkspacesResponse>({
-    queryKey: ["workspaces", filters],
-    queryFn: () => api.getWorkspaces(filters),
+  // The search input is stored in filters.search so it survives page reload and is shareable.
+  // We keep raw input in a separate state so we can show the un-debounced text in the input.
+  // However, since useFiltersWithUrl already syncs to URL, we use filters.search as the
+  // source of truth for the controlled input and debounce it before sending to the query.
+  const rawSearch = filters.search ?? "";
+
+  // Debounce the raw search value — 300 ms delay, 2-char minimum enforced in useWorkspaces
+  const debouncedSearch = useDebounce(rawSearch, 300);
+
+  // Merge debounced search with other filters for the query
+  const { data, isLoading, isError, isFetching } = useWorkspaces({
+    type: filters.type,
+    availability: filters.availability,
+    minPrice: filters.minPrice,
+    maxPrice: filters.maxPrice,
+    search: debouncedSearch,
   });
 
+  const workspaces = data?.workspaces ?? [];
+  const count = workspaces.length;
+
+  // Handler: update search in URL state
+  const handleSearchChange = (value: string) => {
+    setFilters({ ...filters, search: value || undefined });
+  };
+
+  // Handler: clear non-search filters
+  const handleFiltersChange = (next: WorkspaceFilters) => {
+    setFilters({ ...next, search: filters.search });
+  };
+
   if (isLoading) {
-    return (
-      <div className="max-w-7xl mx-auto p-6">
-        <div className="mb-8">
-          <div className="h-8 bg-gray-200 rounded w-1/4 mb-2 animate-pulse"></div>
-          <div className="h-4 bg-gray-200 rounded w-1/3 animate-pulse"></div>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="bg-white rounded-lg shadow-md h-80 animate-pulse" />
-          ))}
-        </div>
-      </div>
-    );
+    return <WorkspaceSkeleton />;
   }
 
   if (isError) {
@@ -119,16 +109,108 @@ function WorkspacesContent() {
         <p className="text-gray-600">Find and book the perfect workspace for your needs</p>
       </div>
 
-      <WorkspaceFiltersComponent filters={filters} onFiltersChange={setFilters} />
+      <WorkspaceFiltersComponent
+        filters={{ type: filters.type, availability: filters.availability, minPrice: filters.minPrice, maxPrice: filters.maxPrice }}
+        onFiltersChange={handleFiltersChange}
+        searchInput={rawSearch}
+        onSearchChange={handleSearchChange}
+      />
+
+      {/* Result count — shown whenever a search or filter is active */}
+      {(debouncedSearch || filters.type || filters.availability !== undefined || filters.maxPrice) && (
+        <p
+          className="text-sm text-gray-500 mb-4"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {isFetching ? (
+            "Searching…"
+          ) : (
+            <>
+              <span className="font-medium text-gray-700">{count}</span>{" "}
+              {count === 1 ? "workspace" : "workspaces"} found
+              {debouncedSearch && debouncedSearch.trim().length >= 2 && (
+                <>
+                  {" "}for <span className="font-medium text-gray-700">&ldquo;{debouncedSearch}&rdquo;</span>
+                </>
+              )}
+            </>
+          )}
+        </p>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {data?.workspaces?.length ? (
-          data.workspaces.map((workspace) => (
-            <WorkspaceCard key={workspace.id} workspace={workspace} />
+        {workspaces.length > 0 ? (
+          workspaces.map((workspace) => (
+            <div
+              key={workspace.id}
+              className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow"
+            >
+              <div className="h-48 bg-gray-200 flex items-center justify-center">
+                {workspace.images?.[0] ? (
+                  <img
+                    src={workspace.images[0]}
+                    alt={workspace.name}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="text-gray-500">No Image</div>
+                )}
+              </div>
+              <div className="p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-lg font-semibold">
+                    <HighlightText text={workspace.name} query={debouncedSearch} />
+                  </h3>
+                  <span
+                    className={`px-2 py-1 rounded-full text-xs font-medium ${getTypeBadgeColor(workspace.type)}`}
+                  >
+                    {workspace.type.replace("-", " ")}
+                  </span>
+                </div>
+                {workspace.description && (
+                  <p className="text-gray-600 text-sm mb-2">
+                    <HighlightText text={workspace.description} query={debouncedSearch} />
+                  </p>
+                )}
+                <p className="text-gray-600 text-sm mb-2">
+                  Capacity: {workspace.capacity} • ${workspace.pricePerHour}/hour
+                </p>
+                <p className="text-gray-600 text-sm mb-4">
+                  {workspace.availability ? (
+                    <span className="text-green-600">Available</span>
+                  ) : (
+                    <span className="text-red-600">Unavailable</span>
+                  )}
+                </p>
+                <Button className="w-full" disabled={!workspace.availability}>
+                  {workspace.availability ? "Book Now" : "Unavailable"}
+                </Button>
+              </div>
+            </div>
           ))
         ) : (
           <div className="col-span-full text-center py-12">
-            <p className="text-gray-500">No workspaces found matching your criteria.</p>
+            {debouncedSearch && debouncedSearch.trim().length >= 2 ? (
+              <div>
+                <p className="text-gray-500 text-lg mb-2">
+                  No workspaces found for &ldquo;<span className="font-medium">{debouncedSearch}</span>&rdquo;.
+                </p>
+                <p className="text-gray-400 text-sm">
+                  Try a different search term or{" "}
+                  <button
+                    type="button"
+                    className="text-blue-600 underline hover:text-blue-800"
+                    onClick={() => handleSearchChange("")}
+                  >
+                    clear the search
+                  </button>
+                  .
+                </p>
+              </div>
+            ) : (
+              <p className="text-gray-500">No workspaces found matching your criteria.</p>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/workspaces/HighlightText.tsx
+++ b/frontend/src/components/workspaces/HighlightText.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+interface HighlightTextProps {
+  /** The full text to display */
+  text: string;
+  /** The search query to highlight within the text */
+  query: string;
+  /** Optional className applied to the wrapping <span> */
+  className?: string;
+  /** Optional className applied to each <mark> element */
+  markClassName?: string;
+}
+
+/**
+ * Renders `text` with every occurrence of `query` (case-insensitive) wrapped
+ * in a `<mark>` element so the match is visually highlighted.
+ *
+ * If `query` is empty, fewer than 2 characters, or not found, the text is
+ * rendered as-is.
+ */
+export function HighlightText({
+  text,
+  query,
+  className,
+  markClassName = "bg-yellow-200 text-yellow-900 rounded px-0.5",
+}: HighlightTextProps) {
+  // Only highlight when the query meets the 2-character minimum
+  if (!query || query.trim().length < 2) {
+    return <span className={className}>{text}</span>;
+  }
+
+  const escapedQuery = query.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(${escapedQuery})`, "gi");
+  const parts = text.split(regex);
+
+  return (
+    <span className={className}>
+      {parts.map((part, index) =>
+        regex.test(part) ? (
+          <mark key={index} className={markClassName}>
+            {part}
+          </mark>
+        ) : (
+          part
+        )
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/workspaces/WorkspaceFilters.tsx
+++ b/frontend/src/components/workspaces/WorkspaceFilters.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import { WorkspaceFilters, WorkspaceType } from "@/types/workspace";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -8,17 +9,99 @@ import { Select } from "@/components/ui/Select";
 interface WorkspaceFiltersProps {
   filters: WorkspaceFilters;
   onFiltersChange: (filters: WorkspaceFilters) => void;
+  /** Controlled search value (raw — not yet debounced) */
+  searchInput: string;
+  onSearchChange: (value: string) => void;
 }
 
-export function WorkspaceFiltersComponent({ filters, onFiltersChange }: WorkspaceFiltersProps) {
+export function WorkspaceFiltersComponent({
+  filters,
+  onFiltersChange,
+  searchInput,
+  onSearchChange,
+}: WorkspaceFiltersProps) {
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const handleClearSearch = () => {
+    onSearchChange("");
+    searchInputRef.current?.focus();
+  };
+
+  const handleClearAll = () => {
+    onFiltersChange({});
+    onSearchChange("");
+    searchInputRef.current?.focus();
+  };
+
   return (
     <div className="bg-white p-4 rounded-lg shadow mb-6">
+      {/* Search row */}
+      <div className="mb-4">
+        <label htmlFor="workspace-search" className="block text-sm font-medium mb-2">
+          Search Workspaces
+        </label>
+        <div className="relative flex items-center">
+          <span className="absolute left-3 text-gray-400 pointer-events-none" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+              />
+            </svg>
+          </span>
+          <Input
+            id="workspace-search"
+            ref={searchInputRef}
+            type="search"
+            placeholder="Search by name or description…"
+            value={searchInput}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="pl-9 pr-9 w-full md:w-96"
+            aria-label="Search workspaces"
+            autoComplete="off"
+          />
+          {searchInput && (
+            <button
+              type="button"
+              onClick={handleClearSearch}
+              aria-label="Clear search"
+              className="absolute right-3 text-gray-400 hover:text-gray-600 focus:outline-none focus:text-gray-600"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Filter row */}
       <div className="flex flex-wrap gap-4 items-end">
         <div>
           <label className="block text-sm font-medium mb-2">Type</label>
           <Select
             value={filters.type || ""}
-            onChange={(e) => onFiltersChange({ ...filters, type: e.target.value as WorkspaceType || undefined })}
+            onChange={(e) =>
+              onFiltersChange({
+                ...filters,
+                type: (e.target.value as WorkspaceType) || undefined,
+              })
+            }
           >
             <option value="">All Types</option>
             <option value="office">Office</option>
@@ -31,10 +114,13 @@ export function WorkspaceFiltersComponent({ filters, onFiltersChange }: Workspac
           <label className="block text-sm font-medium mb-2">Availability</label>
           <Select
             value={filters.availability === undefined ? "" : filters.availability.toString()}
-            onChange={(e) => onFiltersChange({
-              ...filters,
-              availability: e.target.value === "" ? undefined : e.target.value === "true"
-            })}
+            onChange={(e) =>
+              onFiltersChange({
+                ...filters,
+                availability:
+                  e.target.value === "" ? undefined : e.target.value === "true",
+              })
+            }
           >
             <option value="">All</option>
             <option value="true">Available</option>
@@ -47,16 +133,15 @@ export function WorkspaceFiltersComponent({ filters, onFiltersChange }: Workspac
             type="number"
             placeholder="Max price"
             value={filters.maxPrice || ""}
-            onChange={(e) => onFiltersChange({
-              ...filters,
-              maxPrice: e.target.value ? parseInt(e.target.value) : undefined
-            })}
+            onChange={(e) =>
+              onFiltersChange({
+                ...filters,
+                maxPrice: e.target.value ? parseInt(e.target.value) : undefined,
+              })
+            }
           />
         </div>
-        <Button
-          variant="outline"
-          onClick={() => onFiltersChange({})}
-        >
+        <Button variant="outline" onClick={handleClearAll}>
           Clear Filters
         </Button>
       </div>

--- a/frontend/src/hooks/__tests__/useDebounce.test.ts
+++ b/frontend/src/hooks/__tests__/useDebounce.test.ts
@@ -1,0 +1,146 @@
+import { act, renderHook } from "@testing-library/react";
+import { useDebounce } from "@/hooks/useDebounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it("returns the initial value immediately before the delay has elapsed", () => {
+    const { result } = renderHook(() => useDebounce("hello", 300));
+    expect(result.current).toBe("hello");
+  });
+
+  it("does not update the debounced value before the delay has elapsed", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: "initial", delay: 300 } }
+    );
+
+    rerender({ value: "updated", delay: 300 });
+
+    // Timer has not fired yet — value should still be the initial one
+    expect(result.current).toBe("initial");
+  });
+
+  it("updates the debounced value after the full delay has elapsed", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: "initial", delay: 300 } }
+    );
+
+    rerender({ value: "updated", delay: 300 });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe("updated");
+  });
+
+  it("resets the timer when the value changes before the delay elapses", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: "a" } }
+    );
+
+    // Change value at 100 ms
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    rerender({ value: "b" });
+
+    // At 200 ms from start (100 ms after second change) — should still be "a"
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe("a");
+
+    // At 400 ms from start (300 ms after second change) — should be "b"
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe("b");
+  });
+
+  it("uses 300 ms as the default delay when no delay argument is provided", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value),
+      { initialProps: { value: "first" } }
+    );
+
+    rerender({ value: "second" });
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe("first");
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe("second");
+  });
+
+  it("works with non-string values (numbers)", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 200),
+      { initialProps: { value: 0 } }
+    );
+
+    rerender({ value: 42 });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe(42);
+  });
+
+  it("works with non-string values (objects)", () => {
+    const initialObj = { a: 1 };
+    const updatedObj = { a: 2 };
+
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 100),
+      { initialProps: { value: initialObj } }
+    );
+
+    rerender({ value: updatedObj });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe(updatedObj);
+  });
+
+  it("a single-character input does not propagate before the delay (simulates 1-char search guard)", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: "" } }
+    );
+
+    // User types one character
+    rerender({ value: "a" });
+
+    // Not yet debounced
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe("");
+
+    // After full delay the debounced value is "a" — but the 2-char guard in
+    // useWorkspaces prevents an API call for single characters
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe("a");
+  });
+});

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Debounces a value by the specified delay in milliseconds.
+ * The returned value only updates after the input value has stopped changing
+ * for at least `delay` ms.
+ *
+ * @param value - The value to debounce
+ * @param delay - Debounce delay in milliseconds (default: 300)
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -167,7 +167,7 @@ export const api = {
   changePassword: (data: { currentPassword: string; newPassword: string }) =>
     post<{ message: string }>('/users/change-password', data),
 
-  getWorkspaces: (params?: { type?: string; availability?: boolean; minPrice?: number; maxPrice?: number }) =>
+  getWorkspaces: (params?: { type?: string; availability?: boolean; minPrice?: number; maxPrice?: number; search?: string }) =>
     get<{ workspaces: import('@/types/workspace').Workspace[] }>('/workspaces', { params }),
 
   getWorkspace: (workspaceId: string) =>

--- a/frontend/src/lib/filters/codecs.ts
+++ b/frontend/src/lib/filters/codecs.ts
@@ -30,3 +30,10 @@ export function numberCodec(): FilterCodec<number> {
     serialize: (value) => String(value),
   };
 }
+
+export function stringCodec(): FilterCodec<string> {
+  return {
+    parse: (raw) => (raw.length > 0 ? raw : undefined),
+    serialize: (value) => value,
+  };
+}

--- a/frontend/src/lib/react-query/hooks/index.ts
+++ b/frontend/src/lib/react-query/hooks/index.ts
@@ -6,3 +6,4 @@ export { useCancelBooking } from "./bookings/useCancelBooking";
 export { useGetNewsletterPreferences } from "./newsletter/useGetNewsletterPreferences";
 export { useUpdateNewsletterPreferences } from "./newsletter/useUpdateNewsletterPreferences";
 export { useUnsubscribeNewsletter } from "./newsletter/useUnsubscribeNewsletter";
+export { useWorkspaces } from "./workspaces/useWorkspaces";

--- a/frontend/src/lib/react-query/hooks/workspaces/useWorkspaces.ts
+++ b/frontend/src/lib/react-query/hooks/workspaces/useWorkspaces.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/apiClient";
+import type { Workspace, WorkspaceFilters } from "@/types/workspace";
+
+export interface UseWorkspacesOptions extends WorkspaceFilters {
+  /**
+   * Search term (minimum 2 characters to trigger an API call).
+   * Shorter strings are ignored and treated as no search.
+   */
+  search?: string;
+}
+
+export interface WorkspacesResponse {
+  workspaces: Workspace[];
+}
+
+/**
+ * Fetches the workspace list with optional filters and full-text search.
+ *
+ * The `search` parameter is included in the query key so React Query
+ * automatically re-fetches (and caches separately) whenever the debounced
+ * search value changes.  A query is only issued when the search term is
+ * empty OR has at least 2 characters; single-character inputs keep the
+ * previous data visible without making a network request.
+ */
+export function useWorkspaces(options: UseWorkspacesOptions = {}) {
+  const { search, ...filters } = options;
+
+  // Normalise: treat 0- or 1-char searches the same as no search
+  const effectiveSearch = search && search.trim().length >= 2 ? search.trim() : undefined;
+
+  const queryKey = ["workspaces", { ...filters, search: effectiveSearch }] as const;
+
+  return useQuery<WorkspacesResponse>({
+    queryKey,
+    queryFn: () =>
+      api.getWorkspaces({
+        ...filters,
+        ...(effectiveSearch ? { search: effectiveSearch } : {}),
+      }),
+    // Keep previous results visible while a new query is in flight so the
+    // list doesn't flash to empty on every keystroke.
+    placeholderData: (prev) => prev,
+  });
+}

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -37,4 +37,5 @@ export interface WorkspaceFilters {
   availability?: boolean;
   minPrice?: number;
   maxPrice?: number;
+  search?: string;
 }


### PR DESCRIPTION
## Summary

Implements live workspace search with a 300ms debounced input, React Query cache key isolation per search term, and highlighted matching text in results.

## Changes

### New files
- `src/hooks/useDebounce.ts` — generic `useDebounce(value, delay)` hook (default 300ms delay)
- `src/components/workspaces/HighlightText.tsx` — wraps matched substrings in `<mark>` elements (case-insensitive, regex-safe, 2-char minimum)
- `src/lib/react-query/hooks/workspaces/useWorkspaces.ts` — React Query hook with `search` in the cache key; 2-char minimum enforced before sending to the API; `placeholderData` keeps previous results visible during refetch

### Modified files
- `src/app/workspaces/page.tsx` — search input with 300ms debounce, result count (`aria-live`), helpful empty state, `HighlightText` on workspace name and description
- `src/components/workspaces/WorkspaceFilters.tsx` — search input with clear (×) button that resets query and returns focus to input
- `src/types/workspace.ts` — added `search?: string` to `WorkspaceFilters`
- `src/lib/apiClient.ts` — added `search?` param to `getWorkspaces`
- `src/lib/filters/codecs.ts` — added `stringCodec()` for URL-synced string filter params
- `src/lib/react-query/hooks/index.ts` — exported `useWorkspaces`

## Tests

29 new tests added, all passing:

| File | Tests |
|------|-------|
| `src/hooks/__tests__/useDebounce.test.ts` | 9 |
| `__tests__/components/workspaces/HighlightText.test.tsx` | 11 |
| `__tests__/lib/react-query/useWorkspaces.test.tsx` | 9 |

Key test coverage:
- Debounce delays emission; timer resets on rapid changes; 1-char input does not pass through before delay
- `HighlightText` renders `<mark>` around matched substring; handles multiple occurrences, case-insensitivity, special regex characters, whitespace-only query
- `useWorkspaces` skips API `search` param for empty/1-char input; includes it for ≥2 chars; trims before sending; different search terms produce separate cache entries

## Behaviour

- Typing 1 character does not trigger an API call (2-char minimum in `useWorkspaces`)
- 300ms debounce prevents a request on every keystroke
- Search term is synced to URL via `useFiltersWithUrl` + `stringCodec` — shareable/bookmark-able
- Clear button (×) inside the input resets search and returns focus
- Result count shown below the input when search or filters are active
- Empty state shows contextual message with a "clear the search" inline link

Closes #356