### PR TITLE
feat(frontend): booking detail status timeline and cancellation flow

### DIFF
--- a/frontend/src/app/dashboard/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/bookings/[id]/page.tsx
@@ -6,6 +6,8 @@ import { api } from "@/lib/apiClient";
 import { useAuthStore } from "@/lib/store/authStore";
 import { BookingStatusBadge } from "@/components/bookings/BookingStatusBadge";
 import { BookingActions } from "@/components/bookings/BookingActions";
+import { BookingStatusTimeline } from "@/components/bookings/BookingStatusTimeline";
+import { RefundCountdown } from "@/components/bookings/RefundCountdown";
 
 export default function BookingDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -72,6 +74,14 @@ export default function BookingDetailPage() {
           </div>
         ))}
       </div>
+
+      <div className="rounded-2xl border border-[#D7CFC6] bg-[#F3EBE2] p-5">
+        <BookingStatusTimeline booking={booking} />
+      </div>
+
+      {(booking.status === "pending" || booking.status === "confirmed") && (
+        <RefundCountdown startTime={booking.startTime} />
+      )}
 
       <BookingActions booking={booking} isAdmin={isAdmin} />
     </div>

--- a/frontend/src/components/bookings/BookingActions.tsx
+++ b/frontend/src/components/bookings/BookingActions.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import { useConfirmBooking } from "@/lib/react-query/hooks/bookings/useConfirmBooking";
 import { useCancelBooking } from "@/lib/react-query/hooks/bookings/useCancelBooking";
 import { Button } from "@/components/ui/Button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/Dialog";
+import { isRefundEligible } from "@/components/bookings/RefundCountdown";
 import type { Booking } from "@/lib/apiClient";
 
 interface Props {
@@ -10,15 +13,31 @@ interface Props {
   isAdmin?: boolean;
 }
 
+const CONFIRM_TEXT = "CANCEL";
+
 export function BookingActions({ booking, isAdmin }: Props) {
   const confirm = useConfirmBooking();
   const cancel = useCancelBooking();
+  const [showCancelModal, setShowCancelModal] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
 
   const isMutating = confirm.isPending || cancel.isPending;
   const isPending = booking.status === "pending";
   const isCancellable = booking.status === "pending" || booking.status === "confirmed";
+  const showCancelButton = isAdmin || isCancellable;
 
   if (!isAdmin && !isCancellable) return null;
+
+  const refundPreview = isRefundEligible(booking.startTime) ? booking.amount : 0;
+
+  const handleConfirmCancel = () => {
+    cancel.mutate(booking.id, {
+      onSuccess: () => {
+        setShowCancelModal(false);
+        setConfirmText("");
+      },
+    });
+  };
 
   return (
     <div className="flex flex-col gap-2">
@@ -32,11 +51,11 @@ export function BookingActions({ booking, isAdmin }: Props) {
             {confirm.isPending ? "Confirming…" : "Confirm"}
           </Button>
         )}
-        {isCancellable && (
+        {showCancelButton && (
           <Button
             variant="ghost"
-            onClick={() => cancel.mutate(booking.id)}
-            disabled={isMutating}
+            onClick={() => setShowCancelModal(true)}
+            disabled={isMutating || !isCancellable}
           >
             {cancel.isPending ? "Cancelling…" : "Cancel"}
           </Button>
@@ -48,6 +67,42 @@ export function BookingActions({ booking, isAdmin }: Props) {
           Syncing with server…
         </p>
       )}
+
+      <Dialog open={showCancelModal} onOpenChange={setShowCancelModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Cancel booking?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-[#6B6B6B]">
+            This action cannot be undone. Estimated refund:{" "}
+            <span className="font-medium text-[#1A1A1A]">${refundPreview.toFixed(2)}</span>
+          </p>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-[#6B6B6B]" htmlFor="cancel-confirm-input">
+              Type &quot;{CONFIRM_TEXT}&quot; to confirm
+            </label>
+            <input
+              id="cancel-confirm-input"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              className="border border-[#D7CFC6] rounded-md px-3 py-2 text-sm"
+              autoComplete="off"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowCancelModal(false)} disabled={cancel.isPending}>
+              Keep booking
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleConfirmCancel}
+              disabled={confirmText !== CONFIRM_TEXT || cancel.isPending}
+            >
+              {cancel.isPending ? "Cancelling…" : "Confirm cancellation"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/components/bookings/BookingStatusTimeline.tsx
+++ b/frontend/src/components/bookings/BookingStatusTimeline.tsx
@@ -1,0 +1,63 @@
+import type { Booking } from "@/lib/apiClient";
+
+interface Step {
+  label: string;
+  timestamp?: string;
+  filled: boolean;
+}
+
+function formatTimestamp(value?: string) {
+  if (!value) return undefined;
+  return new Date(value).toLocaleString();
+}
+
+export function BookingStatusTimeline({ booking }: { booking: Booking }) {
+  const isCancelled = booking.status === "cancelled";
+  const isCompleted = booking.status === "completed";
+  const isConfirmedOrLater = booking.status === "confirmed" || isCompleted;
+
+  const steps: Step[] = [
+    {
+      label: "Created",
+      timestamp: formatTimestamp(booking.createdAt),
+      filled: true,
+    },
+    {
+      label: "Confirmed",
+      timestamp: isConfirmedOrLater ? formatTimestamp(booking.updatedAt) : undefined,
+      filled: isConfirmedOrLater,
+    },
+    {
+      label: isCancelled ? "Cancelled" : "Completed",
+      timestamp: isCancelled || isCompleted ? formatTimestamp(booking.updatedAt) : undefined,
+      filled: isCancelled || isCompleted,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="booking-status-timeline">
+      {steps.map((step, i) => (
+        <div key={step.label} className="flex gap-3">
+          <div className="flex flex-col items-center">
+            <span
+              data-testid={`timeline-step-${step.label.toLowerCase()}`}
+              data-filled={step.filled}
+              className={`h-3 w-3 rounded-full ${
+                step.filled ? "bg-[#1A1A1A]" : "bg-[#D7CFC6]"
+              }`}
+            />
+            {i < steps.length - 1 && (
+              <span className={`w-px flex-1 min-h-[1.5rem] ${step.filled ? "bg-[#1A1A1A]" : "bg-[#D7CFC6]"}`} />
+            )}
+          </div>
+          <div className="pb-2">
+            <p className={`text-sm font-medium ${step.filled ? "text-[#1A1A1A]" : "text-[#6B6B6B]"}`}>
+              {step.label}
+            </p>
+            {step.timestamp && <p className="text-xs text-[#6B6B6B]">{step.timestamp}</p>}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/bookings/RefundCountdown.tsx
+++ b/frontend/src/components/bookings/RefundCountdown.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const REFUND_WINDOW_HOURS = 24;
+
+export function getRefundDeadline(startTime: string | Date) {
+  return new Date(new Date(startTime).getTime() - REFUND_WINDOW_HOURS * 60 * 60 * 1000);
+}
+
+export function isRefundEligible(startTime: string | Date, now: Date = new Date()) {
+  return getRefundDeadline(startTime).getTime() > now.getTime();
+}
+
+function formatRemaining(ms: number) {
+  const totalMinutes = Math.max(0, Math.floor(ms / 60000));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+}
+
+export function RefundCountdown({ startTime }: { startTime: string }) {
+  const deadline = getRefundDeadline(startTime);
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const remainingMs = deadline.getTime() - now.getTime();
+  if (remainingMs <= 0) return null;
+
+  return (
+    <p className="text-xs text-[#6B6B6B]" data-testid="refund-countdown">
+      Refund eligible until {deadline.toLocaleString()} ({formatRemaining(remainingMs)} remaining)
+    </p>
+  );
+}

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -103,6 +103,9 @@ export interface Booking {
   endTime: string;
   amount: number;
   status: BookingStatus;
+  createdAt?: string;
+  updatedAt?: string;
+  refundAmount?: number;
 }
 
 export interface AttendanceRecord {


### PR DESCRIPTION
## Summary
- Added `BookingStatusTimeline` component showing Created → Confirmed → Completed/Cancelled steps with timestamps
- Added `RefundCountdown` showing refund-eligible window (24h before start)
- Cancel action now opens a confirmation modal requiring typed confirmation text and shows an estimated refund preview
- Cancel button is now disabled (not hidden) for non-cancellable bookings when viewed by an admin

Closes #358

## Validation performed
- `npx tsc --noEmit` — no new type errors introduced (pre-existing unrelated test-config errors remain)
- `npx eslint` on all changed files — clean