### PR TITLE
feat(frontend): add hourly availability calendar to workspace detail

### DIFF
--- a/frontend/__tests__/components/workspaces/WorkspaceCalendar.test.tsx
+++ b/frontend/__tests__/components/workspaces/WorkspaceCalendar.test.tsx
@@ -1,0 +1,412 @@
+/**
+ * Unit tests for WorkspaceCalendar component
+ *
+ * Covers:
+ * - Loading skeleton while data is fetching
+ * - Error state
+ * - Fully-booked workspace → all slot buttons disabled
+ * - Fully-available workspace → at least some slot buttons enabled
+ * - Clicking an available slot calls onSlotSelect with correct times
+ * - Booked slots cannot trigger onSlotSelect
+ * - Week navigation (prev/next/current week)
+ * - Time-zone conversion: UTC slot times rendered via Intl.DateTimeFormat
+ * - Skeleton component renders correctly
+ */
+
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+  act,
+} from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { WorkspaceCalendar } from "@/components/workspaces/WorkspaceCalendar";
+import { WorkspaceCalendarSkeleton } from "@/components/workspaces/WorkspaceCalendarSkeleton";
+import * as apiClient from "@/lib/apiClient";
+import type { AvailabilitySlot } from "@/types/workspace";
+import type { SlotSelection } from "@/components/workspaces/WorkspaceCalendar";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock("@/lib/apiClient");
+
+jest.mock("lucide-react", () => ({
+  ChevronLeft: (props: React.SVGProps<SVGElement>) => <svg data-testid="icon-prev" />,
+  ChevronRight: (props: React.SVGProps<SVGElement>) => <svg data-testid="icon-next" />,
+}));
+
+// ─── Test Helpers ─────────────────────────────────────────────────────────────
+
+const makeQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qcRef = React.useRef<QueryClient | null>(null);
+  if (!qcRef.current) qcRef.current = makeQueryClient();
+  return (
+    <QueryClientProvider client={qcRef.current}>{children}</QueryClientProvider>
+  );
+}
+
+function renderCalendar(props: Partial<React.ComponentProps<typeof WorkspaceCalendar>> = {}) {
+  return render(
+    <WorkspaceCalendar workspaceId="ws-1" {...props} />,
+    { wrapper: Wrapper }
+  );
+}
+
+/**
+ * Builds a 24-slot availability array.
+ * Hours in `bookedHours` (UTC) have available=0; all others have `availableSeats`.
+ */
+function makeSlots(
+  dateStr: string,
+  capacity = 4,
+  bookedHours: number[] = [],
+  availableSeats = capacity
+): AvailabilitySlot[] {
+  return Array.from({ length: 24 }, (_, h) => ({
+    hour: `${dateStr}T${String(h).padStart(2, "0")}:00:00.000Z`,
+    available: bookedHours.includes(h) ? 0 : availableSeats,
+    capacity,
+  }));
+}
+
+/** Today as YYYY-MM-DD in local time — same as what the component passes to the API */
+function todayLocalDateStr(): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date());
+}
+
+/** Helper: wait for the calendar grid to appear */
+async function waitForCalendar() {
+  await waitFor(() => {
+    expect(screen.getByTestId("workspace-calendar")).toBeInTheDocument();
+  });
+}
+
+/** All slot buttons (data-testid="calendar-slot") */
+function getSlotButtons(): HTMLElement[] {
+  return screen.queryAllByTestId("calendar-slot");
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+let mockGetWorkspaceAvailability: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetWorkspaceAvailability = jest.fn();
+  (apiClient.api as any) = {
+    ...(apiClient.api as any),
+    getWorkspaceAvailability: mockGetWorkspaceAvailability,
+  };
+});
+
+// ─── WorkspaceCalendarSkeleton ────────────────────────────────────────────────
+
+describe("WorkspaceCalendarSkeleton", () => {
+  it("renders with aria-hidden and correct testid", () => {
+    const { container } = render(<WorkspaceCalendarSkeleton />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute("aria-hidden", "true");
+    expect(root).toHaveAttribute("data-testid", "workspace-calendar-skeleton");
+  });
+
+  it("does not contain any interactive buttons", () => {
+    render(<WorkspaceCalendarSkeleton />);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+});
+
+// ─── WorkspaceCalendar ────────────────────────────────────────────────────────
+
+describe("WorkspaceCalendar", () => {
+  // ── Loading ────────────────────────────────────────────────────────────────
+
+  describe("loading state", () => {
+    it("shows the skeleton while data is loading", () => {
+      mockGetWorkspaceAvailability.mockReturnValue(new Promise(() => {}));
+      renderCalendar();
+      expect(screen.getByTestId("workspace-calendar-skeleton")).toBeInTheDocument();
+      expect(screen.queryByTestId("workspace-calendar")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Error ──────────────────────────────────────────────────────────────────
+
+  describe("error state", () => {
+    it("shows an error alert when any day query fails", async () => {
+      mockGetWorkspaceAvailability.mockRejectedValue(new Error("Network error"));
+      renderCalendar();
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+      expect(screen.getByRole("alert")).toHaveTextContent(/failed to load availability/i);
+    });
+  });
+
+  // ── Fully-booked workspace ─────────────────────────────────────────────────
+
+  describe("fully-booked workspace", () => {
+    it("renders all slot buttons as disabled", async () => {
+      const today = todayLocalDateStr();
+      const allHours = Array.from({ length: 24 }, (_, h) => h);
+      mockGetWorkspaceAvailability.mockResolvedValue(makeSlots(today, 4, allHours));
+
+      renderCalendar();
+      await waitForCalendar();
+
+      const slotBtns = getSlotButtons();
+      expect(slotBtns.length).toBeGreaterThan(0);
+      slotBtns.forEach((btn) => expect(btn).toBeDisabled());
+    });
+
+    it("every slot button's accessible name mentions 'fully booked'", async () => {
+      const today = todayLocalDateStr();
+      const allHours = Array.from({ length: 24 }, (_, h) => h);
+      mockGetWorkspaceAvailability.mockResolvedValue(makeSlots(today, 4, allHours));
+
+      renderCalendar();
+      await waitForCalendar();
+
+      const slotBtns = getSlotButtons();
+      expect(slotBtns.length).toBeGreaterThan(0);
+      slotBtns.forEach((btn) => {
+        expect(btn.getAttribute("aria-label") ?? "").toMatch(/fully booked/i);
+      });
+    });
+  });
+
+  // ── Available workspace ────────────────────────────────────────────────────
+
+  describe("available workspace", () => {
+    it("renders enabled slot buttons for operating hours (08:00–19:00)", async () => {
+      const today = todayLocalDateStr();
+      mockGetWorkspaceAvailability.mockResolvedValue(makeSlots(today, 4, []));
+
+      renderCalendar();
+      await waitForCalendar();
+
+      const enabledSlots = getSlotButtons().filter((btn) => !btn.hasAttribute("disabled"));
+      // 12 operating hours × 7 days = 84 enabled slots max
+      expect(enabledSlots.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Slot click → onSlotSelect ──────────────────────────────────────────────
+
+  describe("slot click → onSlotSelect callback", () => {
+    it("calls onSlotSelect with startTime, endTime (1 hour apart) and slot when an available slot is clicked", async () => {
+      const today = todayLocalDateStr();
+      // Only hour 10 UTC is available
+      const booked = [0,1,2,3,4,5,6,7,8,9,11,12,13,14,15,16,17,18,19,20,21,22,23];
+      mockGetWorkspaceAvailability.mockResolvedValue(makeSlots(today, 4, booked));
+
+      const onSlotSelect = jest.fn();
+      renderCalendar({ onSlotSelect });
+      await waitForCalendar();
+
+      const enabledSlots = getSlotButtons().filter((btn) => !btn.hasAttribute("disabled"));
+      expect(enabledSlots.length).toBeGreaterThanOrEqual(1);
+
+      await act(async () => {
+        fireEvent.click(enabledSlots[0]);
+      });
+
+      expect(onSlotSelect).toHaveBeenCalledTimes(1);
+
+      const sel: SlotSelection = onSlotSelect.mock.calls[0][0];
+      // startTime must be a datetime-local string
+      expect(sel.startTime).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+      // endTime is exactly 1 hour later
+      const diff = new Date(sel.endTime).getTime() - new Date(sel.startTime).getTime();
+      expect(diff).toBe(60 * 60 * 1000);
+      // Slot object is passed through
+      expect(sel.slot).toMatchObject({ available: 4, capacity: 4 });
+    });
+
+    it("does NOT call onSlotSelect when a disabled (booked) slot is clicked", async () => {
+      const today = todayLocalDateStr();
+      const allHours = Array.from({ length: 24 }, (_, h) => h);
+      mockGetWorkspaceAvailability.mockResolvedValue(makeSlots(today, 4, allHours));
+
+      const onSlotSelect = jest.fn();
+      renderCalendar({ onSlotSelect });
+      await waitForCalendar();
+
+      const disabledSlots = getSlotButtons().filter((btn) => btn.hasAttribute("disabled"));
+      expect(disabledSlots.length).toBeGreaterThan(0);
+
+      fireEvent.click(disabledSlots[0]);
+      expect(onSlotSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Week navigation ────────────────────────────────────────────────────────
+
+  describe("week navigation", () => {
+    beforeEach(() => {
+      mockGetWorkspaceAvailability.mockResolvedValue([]);
+    });
+
+    it("renders previous-week and next-week nav buttons", async () => {
+      renderCalendar();
+      await waitForCalendar();
+
+      expect(screen.getByLabelText("Previous week")).toBeInTheDocument();
+      expect(screen.getByLabelText("Next week")).toBeInTheDocument();
+    });
+
+    it("advances the week label when next-week is clicked", async () => {
+      renderCalendar();
+      await waitForCalendar();
+
+      const weekBtn = screen.getByTestId("week-range-btn");
+      const initialLabel = weekBtn.textContent;
+
+      fireEvent.click(screen.getByLabelText("Next week"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("week-range-btn").textContent).not.toBe(initialLabel);
+      });
+    });
+
+    it("goes back the week label when previous-week is clicked", async () => {
+      renderCalendar();
+      await waitForCalendar();
+
+      const weekBtn = screen.getByTestId("week-range-btn");
+      const initialLabel = weekBtn.textContent;
+
+      fireEvent.click(screen.getByLabelText("Previous week"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("week-range-btn").textContent).not.toBe(initialLabel);
+      });
+    });
+
+    it("returns to the current week when the week-range button is clicked", async () => {
+      renderCalendar();
+      await waitForCalendar();
+
+      const weekBtn = screen.getByTestId("week-range-btn");
+      const initialLabel = weekBtn.textContent;
+
+      fireEvent.click(screen.getByLabelText("Next week"));
+      await waitFor(() => {
+        expect(screen.getByTestId("week-range-btn").textContent).not.toBe(initialLabel);
+      });
+
+      fireEvent.click(screen.getByTestId("week-range-btn"));
+      await waitFor(() => {
+        expect(screen.getByTestId("week-range-btn").textContent).toBe(initialLabel);
+      });
+    });
+  });
+
+  // ── Accessibility ──────────────────────────────────────────────────────────
+
+  describe("accessibility", () => {
+    beforeEach(() => {
+      mockGetWorkspaceAvailability.mockResolvedValue([]);
+    });
+
+    it("renders a landmark region labelled by the Availability heading", async () => {
+      renderCalendar();
+      await waitForCalendar();
+
+      const region = screen.getByRole("region");
+      expect(within(region).getByRole("heading", { level: 2 })).toHaveTextContent(
+        /availability/i
+      );
+    });
+
+    it("renders the slot grid with role=grid", async () => {
+      renderCalendar();
+      await waitForCalendar();
+      expect(screen.getByRole("grid")).toBeInTheDocument();
+    });
+
+    it("available slot buttons each have a descriptive aria-label mentioning 'seats available'", async () => {
+      const today = todayLocalDateStr();
+      mockGetWorkspaceAvailability.mockResolvedValue(makeSlots(today, 4, []));
+
+      renderCalendar();
+      await waitForCalendar();
+
+      const enabledSlots = getSlotButtons().filter((btn) => !btn.hasAttribute("disabled"));
+      expect(enabledSlots.length).toBeGreaterThan(0);
+      enabledSlots.forEach((btn) => {
+        expect(btn.getAttribute("aria-label") ?? "").toMatch(/seats available/i);
+      });
+    });
+  });
+
+  // ── Timezone conversion ────────────────────────────────────────────────────
+
+  describe("timezone conversion", () => {
+    it("maps UTC slot timestamps to local time for aria-labels", async () => {
+      const today = todayLocalDateStr();
+      mockGetWorkspaceAvailability.mockResolvedValue(makeSlots(today, 4, []));
+
+      renderCalendar();
+      await waitForCalendar();
+
+      // JSDOM runs in UTC so UTC 10:00 → local 10:00 AM
+      const expectedTime = new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      }).format(new Date(`${today}T10:00:00.000Z`));
+
+      const slotBtns = getSlotButtons();
+      const matchingBtn = slotBtns.find((btn) =>
+        (btn.getAttribute("aria-label") ?? "").includes(expectedTime)
+      );
+      expect(matchingBtn).toBeDefined();
+    });
+
+    it("passes YYYY-MM-DD date strings to the availability API", async () => {
+      mockGetWorkspaceAvailability.mockResolvedValue([]);
+
+      renderCalendar();
+
+      await waitFor(() => {
+        expect(mockGetWorkspaceAvailability).toHaveBeenCalled();
+      });
+
+      mockGetWorkspaceAvailability.mock.calls.forEach(([_id, dateArg]) => {
+        expect(dateArg).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      });
+    });
+  });
+
+  // ── Legend ─────────────────────────────────────────────────────────────────
+
+  describe("legend", () => {
+    it("renders colour-coded legend entries", async () => {
+      mockGetWorkspaceAvailability.mockResolvedValue([]);
+
+      renderCalendar();
+      await waitForCalendar();
+
+      expect(screen.getByText(/available/i)).toBeInTheDocument();
+      expect(screen.getByText(/fully booked/i)).toBeInTheDocument();
+      expect(screen.getByText(/outside operating hours/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/__tests__/lib/react-query/useWorkspaceAvailability.test.tsx
+++ b/frontend/__tests__/lib/react-query/useWorkspaceAvailability.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for useWorkspaceAvailability React Query hook.
+ *
+ * Covers:
+ * - Returns data when API call succeeds
+ * - Exposes isError when the API call fails
+ * - Does NOT fire when workspaceId is empty
+ * - Does NOT fire when date is empty
+ * - Uses the correct query key
+ * - Calls the API with the correct arguments
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { useWorkspaceAvailability } from "@/lib/react-query/hooks/workspaces/useWorkspaceAvailability";
+import * as apiClient from "@/lib/apiClient";
+import { createWrapper } from "./test-utils";
+import type { AvailabilitySlot } from "@/types/workspace";
+
+jest.mock("@/lib/apiClient");
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Builds a minimal 24-slot availability array */
+function makeSlots(capacity = 4, available = 4): AvailabilitySlot[] {
+  return Array.from({ length: 24 }, (_, h) => ({
+    hour: `2026-07-28T${String(h).padStart(2, "0")}:00:00.000Z`,
+    available,
+    capacity,
+  }));
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+let mockGetWorkspaceAvailability: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetWorkspaceAvailability = jest.fn();
+  (apiClient.api as any) = {
+    ...(apiClient.api as any),
+    getWorkspaceAvailability: mockGetWorkspaceAvailability,
+  };
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useWorkspaceAvailability", () => {
+  it("returns data when the API call succeeds", async () => {
+    const slots = makeSlots();
+    mockGetWorkspaceAvailability.mockResolvedValueOnce(slots);
+
+    const { result } = renderHook(
+      () => useWorkspaceAvailability("ws-1", "2026-07-28"),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(slots);
+  });
+
+  it("calls the API with the correct workspaceId and date", async () => {
+    mockGetWorkspaceAvailability.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(
+      () => useWorkspaceAvailability("ws-abc", "2026-08-01"),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGetWorkspaceAvailability).toHaveBeenCalledWith("ws-abc", "2026-08-01");
+  });
+
+  it("exposes isError when the API call fails", async () => {
+    mockGetWorkspaceAvailability.mockRejectedValueOnce(new Error("Server error"));
+
+    const { result } = renderHook(
+      () => useWorkspaceAvailability("ws-1", "2026-07-28"),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("does NOT call the API when workspaceId is empty", async () => {
+    mockGetWorkspaceAvailability.mockResolvedValue([]);
+
+    const { result } = renderHook(
+      () => useWorkspaceAvailability("", "2026-07-28"),
+      { wrapper: createWrapper() }
+    );
+
+    // The query should remain in a pending/idle state
+    await new Promise((r) => setTimeout(r, 100));
+    expect(mockGetWorkspaceAvailability).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false); // idle, not loading
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("does NOT call the API when date is empty", async () => {
+    mockGetWorkspaceAvailability.mockResolvedValue([]);
+
+    const { result } = renderHook(
+      () => useWorkspaceAvailability("ws-1", ""),
+      { wrapper: createWrapper() }
+    );
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(mockGetWorkspaceAvailability).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("uses different query keys for different dates (cache isolation)", () => {
+    mockGetWorkspaceAvailability
+      .mockResolvedValueOnce(makeSlots(4, 4))
+      .mockResolvedValueOnce(makeSlots(4, 0));
+
+    const wrapper = createWrapper();
+
+    const { result: r1 } = renderHook(
+      () => useWorkspaceAvailability("ws-1", "2026-07-28"),
+      { wrapper }
+    );
+    const { result: r2 } = renderHook(
+      () => useWorkspaceAvailability("ws-1", "2026-07-29"),
+      { wrapper }
+    );
+
+    // Both hooks fire independently for different dates
+    expect(mockGetWorkspaceAvailability).toHaveBeenCalledWith("ws-1", "2026-07-28");
+    expect(mockGetWorkspaceAvailability).toHaveBeenCalledWith("ws-1", "2026-07-29");
+    expect(mockGetWorkspaceAvailability).toHaveBeenCalledTimes(2);
+
+    void r1;
+    void r2;
+  });
+
+  it("uses different query keys for different workspaceIds (cache isolation)", () => {
+    mockGetWorkspaceAvailability
+      .mockResolvedValueOnce(makeSlots(4, 4))
+      .mockResolvedValueOnce(makeSlots(2, 1));
+
+    const wrapper = createWrapper();
+
+    const { result: r1 } = renderHook(
+      () => useWorkspaceAvailability("ws-1", "2026-07-28"),
+      { wrapper }
+    );
+    const { result: r2 } = renderHook(
+      () => useWorkspaceAvailability("ws-2", "2026-07-28"),
+      { wrapper }
+    );
+
+    expect(mockGetWorkspaceAvailability).toHaveBeenCalledWith("ws-1", "2026-07-28");
+    expect(mockGetWorkspaceAvailability).toHaveBeenCalledWith("ws-2", "2026-07-28");
+    expect(mockGetWorkspaceAvailability).toHaveBeenCalledTimes(2);
+
+    void r1;
+    void r2;
+  });
+
+  it("returns an array of AvailabilitySlot objects with the correct shape", async () => {
+    const slots = makeSlots(10, 7);
+    mockGetWorkspaceAvailability.mockResolvedValueOnce(slots);
+
+    const { result } = renderHook(
+      () => useWorkspaceAvailability("ws-1", "2026-07-28"),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data ?? [];
+    expect(data).toHaveLength(24);
+    data.forEach((slot) => {
+      expect(slot).toHaveProperty("hour");
+      expect(slot).toHaveProperty("available");
+      expect(slot).toHaveProperty("capacity");
+      expect(typeof slot.hour).toBe("string");
+      expect(typeof slot.available).toBe("number");
+      expect(typeof slot.capacity).toBe("number");
+    });
+  });
+});

--- a/frontend/src/app/workspaces/[id]/page.tsx
+++ b/frontend/src/app/workspaces/[id]/page.tsx
@@ -11,19 +11,34 @@ import { useToast } from "@/components/ui/ToastProvider";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { WorkspaceCalendar, type SlotSelection } from "@/components/workspaces/WorkspaceCalendar";
 
 interface WorkspaceResponse {
   workspace: Workspace;
 }
 
-function BookingForm({ workspace }: { workspace: Workspace }) {
+function BookingForm({
+  workspace,
+  initialStartTime = "",
+  initialEndTime = "",
+}: {
+  workspace: Workspace;
+  initialStartTime?: string;
+  initialEndTime?: string;
+}) {
   const { token } = useAuthStore();
   const { showToast } = useToast();
   const [isBooking, setIsBooking] = useState(false);
   const [formData, setFormData] = useState({
-    startTime: "",
-    endTime: "",
+    startTime: initialStartTime,
+    endTime: initialEndTime,
   });
+
+  // Sync external pre-fill values when the user clicks a calendar slot
+  // (only update if the new value actually differs to avoid infinite loops)
+  if (formData.startTime !== initialStartTime && initialStartTime) {
+    setFormData({ startTime: initialStartTime, endTime: initialEndTime });
+  }
 
   const calculateTotal = () => {
     if (!formData.startTime || !formData.endTime) return 0;
@@ -63,20 +78,30 @@ function BookingForm({ workspace }: { workspace: Workspace }) {
       <h3 className="text-lg font-semibold mb-4">Book This Workspace</h3>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium mb-2">Start Time</label>
+          <label className="block text-sm font-medium mb-2" htmlFor="startTime">
+            Start Time
+          </label>
           <Input
+            id="startTime"
             type="datetime-local"
             value={formData.startTime}
-            onChange={(e) => setFormData(prev => ({ ...prev, startTime: e.target.value }))}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, startTime: e.target.value }))
+            }
             required
           />
         </div>
         <div>
-          <label className="block text-sm font-medium mb-2">End Time</label>
+          <label className="block text-sm font-medium mb-2" htmlFor="endTime">
+            End Time
+          </label>
           <Input
+            id="endTime"
             type="datetime-local"
             value={formData.endTime}
-            onChange={(e) => setFormData(prev => ({ ...prev, endTime: e.target.value }))}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, endTime: e.target.value }))
+            }
             required
           />
         </div>
@@ -91,7 +116,11 @@ function BookingForm({ workspace }: { workspace: Workspace }) {
           className="w-full"
           disabled={isBooking || !workspace.availability}
         >
-          {isBooking ? "Booking..." : workspace.availability ? "Confirm Booking" : "Unavailable"}
+          {isBooking
+            ? "Booking..."
+            : workspace.availability
+            ? "Confirm Booking"
+            : "Unavailable"}
         </Button>
       </form>
     </div>
@@ -102,11 +131,22 @@ export default function WorkspaceDetailPage() {
   const params = useParams();
   const workspaceId = params.id as string;
 
+  // Track the pre-filled times from a calendar slot click
+  const [prefillStart, setPrefillStart] = useState("");
+  const [prefillEnd, setPrefillEnd] = useState("");
+
   const { data, isLoading, isError } = useQuery<WorkspaceResponse>({
     queryKey: ["workspace", workspaceId],
     queryFn: () => api.getWorkspace(workspaceId),
     enabled: !!workspaceId,
   });
+
+  const handleSlotSelect = (selection: SlotSelection) => {
+    setPrefillStart(selection.startTime);
+    setPrefillEnd(selection.endTime);
+    // Scroll to the booking form on mobile
+    document.getElementById("booking-form")?.scrollIntoView({ behavior: "smooth" });
+  };
 
   if (isLoading) {
     return (
@@ -183,7 +223,9 @@ export default function WorkspaceDetailPage() {
               </div>
               <div className="flex items-center">
                 <MapPin className="h-5 w-5 mr-2 text-gray-500" />
-                <span className="text-sm capitalize">{workspace.type.replace("-", " ")}</span>
+                <span className="text-sm capitalize">
+                  {workspace.type.replace("-", " ")}
+                </span>
               </div>
             </div>
 
@@ -210,12 +252,32 @@ export default function WorkspaceDetailPage() {
               </div>
             )}
           </div>
+
+          {/* Availability Calendar */}
+          <div className="bg-white p-6 rounded-lg shadow-md">
+            <ErrorBoundary
+              section="WorkspaceCalendar"
+              message="Failed to load the availability calendar."
+            >
+              <WorkspaceCalendar
+                workspaceId={workspaceId}
+                onSlotSelect={handleSlotSelect}
+              />
+            </ErrorBoundary>
+          </div>
         </div>
 
         {/* Booking Form */}
-        <div className="lg:col-span-1">
-          <ErrorBoundary section="WorkspaceCalendar" message="Failed to load the booking scheduler.">
-            <BookingForm workspace={workspace} />
+        <div className="lg:col-span-1" id="booking-form">
+          <ErrorBoundary
+            section="BookingForm"
+            message="Failed to load the booking form."
+          >
+            <BookingForm
+              workspace={workspace}
+              initialStartTime={prefillStart}
+              initialEndTime={prefillEnd}
+            />
           </ErrorBoundary>
         </div>
       </div>

--- a/frontend/src/components/workspaces/WorkspaceCalendar.tsx
+++ b/frontend/src/components/workspaces/WorkspaceCalendar.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import { useState, useCallback, useId } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { useWorkspaceAvailability } from "@/lib/react-query/hooks/workspaces/useWorkspaceAvailability";
+import { WorkspaceCalendarSkeleton } from "./WorkspaceCalendarSkeleton";
+import type { AvailabilitySlot } from "@/types/workspace";
+
+// ─── Operating hours ──────────────────────────────────────────────────────────
+/** First operating hour (UTC), inclusive */
+const OPERATING_START = 8;
+/** Last operating hour (UTC), exclusive (so 20 → last visible slot is 19:00) */
+const OPERATING_END = 20;
+/** Number of visible hour rows */
+const HOUR_COUNT = OPERATING_END - OPERATING_START; // 12
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a YYYY-MM-DD string for the given Date in the user's local time zone.
+ * We use Intl.DateTimeFormat to avoid manual offset arithmetic.
+ */
+function toLocalDateString(date: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date); // en-CA produces YYYY-MM-DD
+}
+
+/**
+ * Returns Monday of the ISO week that contains `date`, in local time.
+ */
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  // getDay(): 0=Sun … 6=Sat → Monday offset
+  const dayOfWeek = d.getDay();
+  const distanceToMonday = (dayOfWeek + 6) % 7; // 0 for Mon, 6 for Sun
+  d.setDate(d.getDate() - distanceToMonday);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/** Adds `days` calendar days to `date` (returns a new Date). */
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+/**
+ * Formats a UTC ISO slot timestamp into the user's local time zone for display.
+ * e.g. "2026-07-28T08:00:00.000Z" → "8:00 AM" in the local TZ.
+ */
+function formatSlotTime(isoString: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(new Date(isoString));
+}
+
+/**
+ * Formats a Date as a short weekday + date label for the column header.
+ * e.g. Mon 28
+ */
+function formatDayHeader(date: Date): { weekday: string; day: number } {
+  const weekday = new Intl.DateTimeFormat(undefined, { weekday: "short" }).format(date);
+  return { weekday, day: date.getDate() };
+}
+
+/**
+ * Formats a Date to a human-readable week range label, e.g.
+ * "Jul 28 – Aug 3, 2026"
+ */
+function formatWeekRange(weekStart: Date): string {
+  const weekEnd = addDays(weekStart, 6);
+  const startLabel = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(weekStart);
+  const endLabel = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(weekEnd);
+  return `${startLabel} – ${endLabel}`;
+}
+
+/**
+ * Converts a slot's UTC ISO timestamp to the local YYYY-MM-DD date string so
+ * we can group slots by the day they appear in the user's time zone.
+ */
+function slotLocalDate(isoString: string): string {
+  return toLocalDateString(new Date(isoString));
+}
+
+/**
+ * Converts a slot's UTC ISO timestamp to the local hour (0–23) so we can
+ * place the slot in the correct row of the grid.
+ */
+function slotLocalHour(isoString: string): number {
+  return new Date(isoString).getHours();
+}
+
+/**
+ * Formats a local Date into a datetime-local string (YYYY-MM-DDTHH:mm).
+ * Used to pre-fill the BookingForm's `datetime-local` inputs.
+ */
+function toDatetimeLocal(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SlotSelection {
+  /** datetime-local string for the start of the selected hour (local time) */
+  startTime: string;
+  /** datetime-local string for the end of the selected hour (local time) */
+  endTime: string;
+  /** The raw availability slot that was clicked */
+  slot: AvailabilitySlot;
+}
+
+export interface WorkspaceCalendarProps {
+  /** UUID of the workspace whose availability to display */
+  workspaceId: string;
+  /**
+   * Called when the user clicks an available time slot.
+   * Receives pre-formatted startTime / endTime strings suitable for a
+   * `<input type="datetime-local">` input.
+   */
+  onSlotSelect?: (selection: SlotSelection) => void;
+  /** Optional additional class names for the root wrapper */
+  className?: string;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface SlotButtonProps {
+  slot: AvailabilitySlot;
+  onSelect: (slot: AvailabilitySlot) => void;
+  isSelected: boolean;
+  labelledById: string;
+}
+
+function SlotButton({ slot, onSelect, isSelected, labelledById }: SlotButtonProps) {
+  const isAvailable = slot.available > 0;
+  const isOutsideHours =
+    slotLocalHour(slot.hour) < OPERATING_START ||
+    slotLocalHour(slot.hour) >= OPERATING_END;
+
+  if (isOutsideHours) {
+    return (
+      <div
+        aria-hidden="true"
+        className="h-9 mx-1 mb-1 rounded-lg bg-gray-100 opacity-40"
+      />
+    );
+  }
+
+  const label = isAvailable
+    ? `${formatSlotTime(slot.hour)}: ${slot.available} of ${slot.capacity} seats available. Click to book.`
+    : `${formatSlotTime(slot.hour)}: fully booked.`;
+
+  return (
+    <button
+      type="button"
+      disabled={!isAvailable}
+      onClick={() => isAvailable && onSelect(slot)}
+      aria-label={label}
+      aria-describedby={labelledById}
+      aria-pressed={isSelected}
+      data-testid="calendar-slot"
+      className={cn(
+        "h-9 mx-1 mb-1 rounded-lg text-xs font-medium transition-all",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1",
+        isAvailable
+          ? cn(
+              "focus-visible:ring-green-500 cursor-pointer",
+              isSelected
+                ? "bg-green-600 text-white ring-2 ring-green-600 ring-offset-1"
+                : "bg-green-100 text-green-800 hover:bg-green-200"
+            )
+          : "bg-red-100 text-red-700 cursor-not-allowed opacity-80 focus-visible:ring-red-400"
+      )}
+    >
+      <span className="sr-only">{label}</span>
+    </button>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+/**
+ * WorkspaceCalendar
+ *
+ * Renders a 7-day × 12-hour CSS Grid showing hourly availability for a
+ * workspace.  Each day's data is fetched independently via `useWorkspaceAvailability`
+ * so React Query can cache and re-use individual day results.
+ *
+ * Accessibility:
+ * - All slot buttons carry an `aria-label` describing the time and availability.
+ * - Disabled (booked) slots are rendered as `<button disabled>` so AT announces
+ *   them as unavailable without being interactive.
+ * - The week navigation buttons have descriptive `aria-label` attributes.
+ * - The grid is wrapped in a `<section>` with an accessible heading.
+ */
+export function WorkspaceCalendar({
+  workspaceId,
+  onSlotSelect,
+  className,
+}: WorkspaceCalendarProps) {
+  const headingId = useId();
+  const legendId = useId();
+
+  const [weekStart, setWeekStart] = useState<Date>(() => getWeekStart(new Date()));
+  const [selectedSlotKey, setSelectedSlotKey] = useState<string | null>(null);
+
+  // Build an array of 7 Date objects for the current week (Mon–Sun local time)
+  const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+  // Pre-format the date strings we'll pass to the API (YYYY-MM-DD, local)
+  const weekDateStrings = weekDays.map(toLocalDateString);
+
+  // Fetch availability for each day independently
+  const dayQueries = weekDays.map((day) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- stable array, see NOTE below
+    return useWorkspaceAvailability(workspaceId, toLocalDateString(day));
+  });
+  // NOTE: The array length is always exactly 7 (constant), so the hook call
+  // order is stable across renders — this is intentional and safe.
+
+  const isLoadingAny = dayQueries.some((q) => q.isLoading);
+  const isErrorAny = dayQueries.some((q) => q.isError);
+
+  // Build a lookup map: localDateString → localHour → AvailabilitySlot
+  const slotMap = new Map<string, Map<number, AvailabilitySlot>>();
+  dayQueries.forEach((q, i) => {
+    if (!q.data) return;
+    const dateStr = weekDateStrings[i];
+    const hourMap = new Map<number, AvailabilitySlot>();
+    q.data.forEach((slot) => {
+      hourMap.set(slotLocalHour(slot.hour), slot);
+    });
+    slotMap.set(dateStr, hourMap);
+  });
+
+  const handleSlotSelect = useCallback(
+    (slot: AvailabilitySlot) => {
+      const key = slot.hour;
+      setSelectedSlotKey((prev) => (prev === key ? null : key));
+
+      const slotDate = new Date(slot.hour);
+      const endDate = new Date(slotDate.getTime() + 60 * 60 * 1000); // +1 hour
+      onSlotSelect?.({
+        startTime: toDatetimeLocal(slotDate),
+        endTime: toDatetimeLocal(endDate),
+        slot,
+      });
+    },
+    [onSlotSelect]
+  );
+
+  const goToPrevWeek = () => setWeekStart((d) => addDays(d, -7));
+  const goToNextWeek = () => setWeekStart((d) => addDays(d, 7));
+  const goToCurrentWeek = () => setWeekStart(getWeekStart(new Date()));
+
+  if (isLoadingAny) {
+    return <WorkspaceCalendarSkeleton />;
+  }
+
+  if (isErrorAny) {
+    return (
+      <div
+        role="alert"
+        className="p-4 rounded-lg bg-red-50 text-red-700 text-sm text-center"
+      >
+        Failed to load availability. Please try again.
+      </div>
+    );
+  }
+
+  // Hour labels for the time-axis (left column)
+  const hourLabels = Array.from({ length: HOUR_COUNT }, (_, i) => {
+    const hour = OPERATING_START + i;
+    // Format as "8 AM", "12 PM", etc. using user's locale
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      hour12: true,
+    }).format(new Date(2000, 0, 1, hour, 0, 0));
+  });
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className={cn("w-full overflow-x-auto", className)}
+      data-testid="workspace-calendar"
+    >
+      {/* ── Heading & week navigation ── */}
+      <div className="flex items-center justify-between mb-3 gap-2 flex-wrap">
+        <h2
+          id={headingId}
+          className="text-base font-semibold text-gray-900 whitespace-nowrap"
+        >
+          Availability
+        </h2>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={goToPrevWeek}
+            aria-label="Previous week"
+            className="p-1.5 rounded-full hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+          </button>
+
+          <button
+            type="button"
+            onClick={goToCurrentWeek}
+            data-testid="week-range-btn"
+            className="text-xs text-gray-500 hover:text-gray-800 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded px-1"
+          >
+            {formatWeekRange(weekStart)}
+          </button>
+
+          <button
+            type="button"
+            onClick={goToNextWeek}
+            aria-label="Next week"
+            className="p-1.5 rounded-full hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+          >
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {/* ── CSS Grid ── */}
+      <div
+        role="grid"
+        aria-label="Workspace availability calendar"
+        className="grid"
+        style={{ gridTemplateColumns: `4rem repeat(7, minmax(0, 1fr))` }}
+      >
+        {/* ── Header row ── */}
+        <div role="rowheader" className="sr-only">
+          Time
+        </div>
+        {weekDays.map((day, d) => {
+          const { weekday, day: dayNum } = formatDayHeader(day);
+          const isToday =
+            toLocalDateString(day) === toLocalDateString(new Date());
+          return (
+            <div
+              key={`hdr-${d}`}
+              role="columnheader"
+              aria-label={new Intl.DateTimeFormat(undefined, {
+                weekday: "long",
+                month: "long",
+                day: "numeric",
+              }).format(day)}
+              className={cn(
+                "text-center text-xs font-medium pb-2 select-none",
+                isToday ? "text-green-700" : "text-gray-500"
+              )}
+            >
+              <span aria-hidden="true">{weekday}</span>
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "ml-1 inline-flex items-center justify-center h-5 w-5 rounded-full text-xs",
+                  isToday && "bg-green-600 text-white font-bold"
+                )}
+              >
+                {dayNum}
+              </span>
+            </div>
+          );
+        })}
+
+        {/* ── Body rows ── */}
+        {hourLabels.map((label, rowIdx) => {
+          const localHour = OPERATING_START + rowIdx;
+          return (
+            <div
+              key={`row-${rowIdx}`}
+              role="row"
+              className="contents"
+            >
+              {/* Time label */}
+              <div
+                role="rowheader"
+                className="pr-2 text-right text-xs text-gray-400 leading-9 select-none whitespace-nowrap"
+                aria-label={label}
+              >
+                <span aria-hidden="true">{label}</span>
+              </div>
+
+              {/* Slot buttons for each day */}
+              {weekDays.map((day, colIdx) => {
+                const dateStr = weekDateStrings[colIdx];
+                const slot = slotMap.get(dateStr)?.get(localHour);
+
+                if (!slot) {
+                  // Data not yet available for this cell (or day outside returned range)
+                  return (
+                    <div
+                      key={`cell-${rowIdx}-${colIdx}`}
+                      role="gridcell"
+                      aria-busy="true"
+                      className="h-9 mx-1 mb-1 rounded-lg bg-gray-100 animate-pulse"
+                    />
+                  );
+                }
+
+                return (
+                  <div
+                    key={`cell-${rowIdx}-${colIdx}`}
+                    role="gridcell"
+                  >
+                    <SlotButton
+                      slot={slot}
+                      onSelect={handleSlotSelect}
+                      isSelected={selectedSlotKey === slot.hour}
+                      labelledById={headingId}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── Legend ── */}
+      <div
+        id={legendId}
+        className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-xs text-gray-500"
+      >
+        <span className="flex items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="inline-block h-3 w-3 rounded bg-green-200 border border-green-400"
+          />
+          Available
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="inline-block h-3 w-3 rounded bg-red-200 border border-red-400"
+          />
+          Fully booked
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="inline-block h-3 w-3 rounded bg-gray-100 border border-gray-300"
+          />
+          Outside operating hours
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/workspaces/WorkspaceCalendarSkeleton.tsx
+++ b/frontend/src/components/workspaces/WorkspaceCalendarSkeleton.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Skeleton } from "@/components/ui/Skeleton";
+
+/** Number of day columns in the calendar (Mon–Sun) */
+const DAYS = 7;
+/** Number of hour rows shown (08:00–19:00 inclusive) */
+const HOURS = 12;
+
+/**
+ * Skeleton that mirrors the WorkspaceCalendar grid layout.
+ *
+ * Structure:
+ *   - Header row: 1 time-label column + 7 day-name columns
+ *   - Body: 12 hour rows × 7 day columns of slot buttons
+ *
+ * aria-hidden="true" is set on the root so screen readers skip the
+ * placeholder entirely and wait for the real calendar to arrive.
+ */
+export function WorkspaceCalendarSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="workspace-calendar-skeleton"
+      className="w-full overflow-x-auto"
+    >
+      {/* Week navigation bar */}
+      <div className="flex items-center justify-between mb-3 px-1">
+        <Skeleton className="h-8 w-8 rounded-full" />
+        <Skeleton className="h-4 w-48 rounded-md" />
+        <Skeleton className="h-8 w-8 rounded-full" />
+      </div>
+
+      {/* Grid */}
+      <div
+        className="grid"
+        style={{
+          gridTemplateColumns: `4rem repeat(${DAYS}, minmax(0, 1fr))`,
+        }}
+      >
+        {/* Header row — blank time-label corner + day names */}
+        <div /> {/* empty corner */}
+        {Array.from({ length: DAYS }).map((_, d) => (
+          <Skeleton key={`hdr-${d}`} className="h-6 mx-1 mb-2 rounded-md" />
+        ))}
+
+        {/* Body rows */}
+        {Array.from({ length: HOURS }).map((_, h) => (
+          <React.Fragment key={`row-${h}`}>
+            {/* Time label cell */}
+            <Skeleton className="h-9 w-12 mb-1 rounded-md" />
+
+            {/* Slot cells for each day */}
+            {Array.from({ length: DAYS }).map((_, d) => (
+              <Skeleton
+                key={`slot-${h}-${d}`}
+                className="h-9 mx-1 mb-1 rounded-lg"
+              />
+            ))}
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 mt-3 px-1">
+        <Skeleton className="h-4 w-24 rounded-md" />
+        <Skeleton className="h-4 w-20 rounded-md" />
+        <Skeleton className="h-4 w-28 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -173,6 +173,9 @@ export const api = {
   getWorkspace: (workspaceId: string) =>
     get<{ workspace: import('@/types/workspace').Workspace }>(`/workspaces/${workspaceId}`),
 
+  getWorkspaceAvailability: (workspaceId: string, date: string) =>
+    get<import('@/types/workspace').AvailabilitySlot[]>(`/workspaces/${workspaceId}/availability`, { params: { date } }),
+
   createBooking: (data: { workspaceId: string; startTime: string; endTime: string }) =>
     post<{ booking: Booking; message: string }>('/bookings', data),
 

--- a/frontend/src/lib/react-query/hooks/index.ts
+++ b/frontend/src/lib/react-query/hooks/index.ts
@@ -7,3 +7,4 @@ export { useGetNewsletterPreferences } from "./newsletter/useGetNewsletterPrefer
 export { useUpdateNewsletterPreferences } from "./newsletter/useUpdateNewsletterPreferences";
 export { useUnsubscribeNewsletter } from "./newsletter/useUnsubscribeNewsletter";
 export { useWorkspaces } from "./workspaces/useWorkspaces";
+export { useWorkspaceAvailability } from "./workspaces/useWorkspaceAvailability";

--- a/frontend/src/lib/react-query/hooks/workspaces/useWorkspaceAvailability.ts
+++ b/frontend/src/lib/react-query/hooks/workspaces/useWorkspaceAvailability.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/apiClient";
+import type { AvailabilitySlot } from "@/types/workspace";
+
+/**
+ * Fetches the 24-slot hourly availability array for a workspace on a given date.
+ *
+ * Query key: ["workspaces", workspaceId, "availability", date]
+ *
+ * @param workspaceId - UUID of the workspace
+ * @param date        - Date string in YYYY-MM-DD format (UTC)
+ */
+export function useWorkspaceAvailability(workspaceId: string, date: string) {
+  return useQuery<AvailabilitySlot[]>({
+    queryKey: ["workspaces", workspaceId, "availability", date],
+    queryFn: () => api.getWorkspaceAvailability(workspaceId, date),
+    enabled: Boolean(workspaceId) && Boolean(date),
+    // Availability changes with new bookings — keep data fresh but avoid
+    // excessive refetches while the user is browsing the week.
+    staleTime: 60_000, // 1 minute
+  });
+}

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -1,5 +1,18 @@
 export type WorkspaceType = "office" | "meeting-room" | "desk" | "conference-room";
 
+/**
+ * A single hourly availability slot returned by
+ * GET /workspaces/:id/availability?date=YYYY-MM-DD
+ */
+export interface AvailabilitySlot {
+  /** ISO 8601 timestamp for the start of this hour slot, e.g. "2026-07-28T08:00:00.000Z" */
+  hour: string;
+  /** Remaining seats available during this hour */
+  available: number;
+  /** Total capacity of the workspace */
+  capacity: number;
+}
+
 export interface Workspace {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

Implements the workspace availability calendar as described in issue #346.

### What's changed

- **`AvailabilitySlot` type** added to `src/types/workspace.ts`
- **`api.getWorkspaceAvailability()`** added to `src/lib/apiClient.ts`
- **`useWorkspaceAvailability`** React Query hook — fetches `GET /workspaces/:id/availability?date=` per day; cached per workspace+date pair
- **`WorkspaceCalendar`** component — 7-day × 12-hour CSS Grid
  - 🟢 Green: available slots — keyboard-navigable, ARIA-labelled, click-to-book
  - 🔴 Red: fully-booked slots — `disabled` buttons, announces as unavailable to AT
  - ⬜ Grey: outside operating hours (08:00–20:00)
  - Week navigation (previous / next / click label to return to today)
  - All times displayed in the **user's local time zone** via native `Intl.DateTimeFormat` — no external TZ library required
- **`WorkspaceCalendarSkeleton`** — loading placeholder matching the grid layout
- **Workspace detail page** (`/workspaces/[id]`) updated: calendar sits above the booking form; clicking an available slot **pre-fills** the `startTime` / `endTime` inputs

### Tests

27 new passing tests:
- `WorkspaceCalendar.test.tsx` (19 tests) — loading skeleton, error state, fully-booked rendering, available rendering, slot click → `onSlotSelect` callback, booked slots do not fire callback, week navigation, timezone conversion, ARIA/legend
- `useWorkspaceAvailability.test.tsx` (8 tests) — success path, error path, disabled when id/date empty, cache-key isolation per date and per workspace

### Testing

```
npm test -- --testPathPatterns="WorkspaceCalendar|useWorkspaceAvailability"
# 27 passed, 0 failed
```

Closes #346